### PR TITLE
up DSC timeout to 10 minutes from 5minutes

### DIFF
--- a/pkg/checks/daemonSet/daemonSet.go
+++ b/pkg/checks/daemonSet/daemonSet.go
@@ -123,7 +123,7 @@ func (dsc *Checker) Interval() time.Duration {
 
 // Timeout returns the maximum run time for this check before it times out
 func (dsc *Checker) Timeout() time.Duration {
-	return time.Minute * 5
+	return time.Minute * 10
 }
 
 // Shutdown signals the DS to begin a cleanup


### PR DESCRIPTION
We have seen the DSC take more than 5 minutes when a newly created node is trying to stand up its initial containers rapidly.  This upps the default timeout for the DSC to 10 minutes.