### PR TITLE
Ds image override

### DIFF
--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -44,7 +44,8 @@ var enableDaemonSetChecks = true       // do daemon set restart checking
 var enablePodRestartChecks = true      // do pod restart checking
 var enablePodStatusChecks = true       // do pod status checking
 var enableForceMaster bool             // force master mode - for debugging
-var enableDebug bool                   // enable deubug logging
+var enableDebug bool                   // enable debug logging
+var DSPauseContainerImageOverride string // specify an alternate location for the DSC pause container - see #114
 
 var kuberhealthy *Kuberhealthy
 
@@ -69,6 +70,7 @@ func init() {
 	flaggy.Bool(&enablePodStatusChecks, "", "podStatusChecks", "Set to false to disable pod lifecycle phase checking.")
 	flaggy.Bool(&enableForceMaster, "", "forceMaster", "Set to true to enable local testing, forced master mode.")
 	flaggy.Bool(&enableDebug, "d", "debug", "Set to true to enable debug.")
+	flaggy.String(&DSPauseContainerImageOverride,  "",  "", "Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.")
 	flaggy.String(&podCheckNamespaces, "", "podCheckNamespaces", "The comma separated list of namespaces on which to check for pod status and restarts, if enabled.")
 	flaggy.Parse()
 
@@ -117,6 +119,10 @@ func main() {
 	// daemonset checking
 	if enableDaemonSetChecks {
 		dsc, err := daemonSet.New()
+		// allow the user to override the image used by the DSC - see #114
+		if len(DSPauseContainerImageOverride) > 1 {
+			dsc.PauseContainerImage = DSPauseContainerImageOverride
+		}
 		if err != nil {
 			log.Fatalln("unable to create daemonset checker:", err)
 		}

--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -120,7 +120,8 @@ func main() {
 	if enableDaemonSetChecks {
 		dsc, err := daemonSet.New()
 		// allow the user to override the image used by the DSC - see #114
-		if len(DSPauseContainerImageOverride) > 1 {
+		if len(DSPauseContainerImageOverride) > 0 {
+			log.Info("Setting DS pause container override image to:", DSPauseContainerImageOverride)
 			dsc.PauseContainerImage = DSPauseContainerImageOverride
 		}
 		if err != nil {

--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -70,7 +70,7 @@ func init() {
 	flaggy.Bool(&enablePodStatusChecks, "", "podStatusChecks", "Set to false to disable pod lifecycle phase checking.")
 	flaggy.Bool(&enableForceMaster, "", "forceMaster", "Set to true to enable local testing, forced master mode.")
 	flaggy.Bool(&enableDebug, "d", "debug", "Set to true to enable debug.")
-	flaggy.String(&DSPauseContainerImageOverride,  "",  "", "Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.")
+	flaggy.String(&DSPauseContainerImageOverride,  "",  "dsPauseContainerImageOverride", "Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.")
 	flaggy.String(&podCheckNamespaces, "", "podCheckNamespaces", "The comma separated list of namespaces on which to check for pod status and restarts, if enabled.")
 	flaggy.Parse()
 

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -1,0 +1,16 @@
+Available flags for use in Kuberhealthy
+
+# Flags
+
+|Flag|Description|Optional|Default|
+|---|---|---|---|
+|`-kubecfg`|Absolute path to a kube config file.|Yes| `$HOME/.kube/config`|
+|`-listenAddress`|The port kuberhealthy will listen on.|Yes| `8080`|
+|`-componentStatusChecks`|Bool to enable/disable Kuberhealthy's [master component](https://kubernetes.io/docs/concepts/overview/components/#master-components) status [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#component-health).|Yes|`True`|
+|`-daemonsetChecks`|Bool to enable/disable Kuberhealthy's test daemon set [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#daemonset-deployment-and-termination).|Yes|`True`|
+|`-podRestartChecks`|Bool to enable/disable Kuberhealthy's pod restart check [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#excessive-pod-restarts).|Yes|`True`|
+|`-podStatusChecks`|Bool to enable/disable Kuberhealthy's pod status check [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#pod-status).|Yes|`True`|
+|`-forceMaster`|Bool to enable/disable election and force master mode.  Useful/Intended for local testing.|Yes|`False`|
+|`-debug`|Bool to enable/disable debug logging.|Yes|`False`|
+|`dsPauseContainerImageOverride`|Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.|Yes|`gcr.io/google_containers/pause:0.8.0`|
+|`podCheckNamespaces`|A comma separated list of namespaces in which to check for pod statuses and restart counts.|Yes|`kube-system`|

--- a/pkg/checks/daemonSet/daemonSet.go
+++ b/pkg/checks/daemonSet/daemonSet.go
@@ -64,6 +64,8 @@ func New() (*Checker, error) {
 func (dsc *Checker) generateDaemonSetSpec() {
 
 	terminationGracePeriod := int64(1)
+	runAsUser := int64(1000)
+	log.Debug("Running daemon set as user 1000.")
 
 	// find all the taints in the cluster and create a toleration for each
 	var err error
@@ -108,6 +110,9 @@ func (dsc *Checker) generateDaemonSetSpec() {
 						apiv1.Container{
 							Name:  "sleep",
 							Image: dsc.PauseContainerImage,
+							SecurityContext: &apiv1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceCPU:    resource.MustParse("0"),

--- a/pkg/checks/daemonSet/daemonSet.go
+++ b/pkg/checks/daemonSet/daemonSet.go
@@ -36,6 +36,7 @@ type Checker struct {
 	shuttingDown      bool
 	DaemonSetDeployed bool
 	DaemonSetName     string
+	PauseContainerImage string
 	hostname          string
 	tolerations       []apiv1.Toleration
 	client            *kubernetes.Clientset
@@ -52,6 +53,7 @@ func New() (*Checker, error) {
 		Namespace:     namespace,
 		DaemonSetName: daemonSetBaseName + "-" + hostname + "-" + strconv.Itoa(int(time.Now().Unix())),
 		hostname:      hostname,
+		PauseContainerImage: "gcr.io/google_containers/pause:0.8.0",
 		tolerations:   tolerations,
 	}
 
@@ -105,7 +107,7 @@ func (dsc *Checker) generateDaemonSetSpec() {
 					Containers: []apiv1.Container{
 						apiv1.Container{
 							Name:  "sleep",
-							Image: "gcr.io/google_containers/pause:0.8.0",
+							Image: dsc.PauseContainerImage,
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceCPU:    resource.MustParse("0"),

--- a/pkg/checks/daemonSet/daemonSet_test.go
+++ b/pkg/checks/daemonSet/daemonSet_test.go
@@ -36,6 +36,27 @@ func TestCleanupOrphans(t *testing.T) {
 	}
 }
 
+func TestPauseContainerOverride(t *testing.T) {
+	// verify that we are getting the expected default value from a new dsc
+	dsc, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dsc.PauseContainerImage != "gcr.io/google_containers/pause:0.8.0" {
+		t.Fatal("Default Pause Container Image is not set or an unexpected value, actual value:", dsc.PauseContainerImage)
+	}
+
+	dscO, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Silly, yes, but this mimics how the program is setting the override value
+	dscO.PauseContainerImage = "another-image-repo/pause:0.8.0"
+	if dscO.PauseContainerImage != "another-image-repo/pause:0.8.0" {
+		t.Fatal("Overridden Pause Container Image is not set or an unexpected value, actual value:", dscO.PauseContainerImage)
+	}
+}
+
 func TestGetAllDaemonsets(t *testing.T) {
 	checker, err := New()
 	if err != nil {


### PR DESCRIPTION
- Allows the user to override the daemon set checker pause container image location - useful if the user is in an environment that forces an image proxy or otherwise wants to use a different image.
- Sets the daemon set checker DS containers to run as user 1000 instead of root - useful for environments that lock down container root users, and just good practice in general.
- Basic test for the above flag
- Documentation for the above flag (and all the rest of kuberhealthy's flags)

See #121 and #114 