### PR TITLE
[Issue-68] Add hard pod anti-affinity to spec

### DIFF
--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -191,6 +191,16 @@ spec:
     spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - kuberhealthy
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - image: quay.io/comcast/kuberhealthy:v1.0.2
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Based off of what I read here: 
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#more-practical-use-cases 
For this issue: 
https://github.com/Comcast/kuberhealthy/issues/68

I think I just specified the podAntiAffinity so that there aren't replicas of Kuberhealthy on a single node -- let me know if this is what you guys were thinking of implementing for this issue and if the implementation is correct!