### PR TITLE
[Issue-7] Expose gracePeriodTimeoutSeconds pod spec as env variable

### DIFF
--- a/cmd/kuberhealthy/kuberhealthy.go
+++ b/cmd/kuberhealthy/kuberhealthy.go
@@ -50,7 +50,7 @@ func NewKuberhealthy() *Kuberhealthy {
 
 // setCheckExecutionError sets an execution error for a check name in
 // its crd status
-func (k *Kuberhealthy) setCheckExecutionError(checkName string, err error) {
+func (k *Kuberhealthy) setCheckExecutionError(checkName string, exErr error) {
 	details := health.NewCheckDetails()
 	check, err := k.getCheck(checkName)
 	if err != nil {
@@ -60,7 +60,8 @@ func (k *Kuberhealthy) setCheckExecutionError(checkName string, err error) {
 		details.Namespace = check.CheckNamespace()
 	}
 	details.OK = false
-	details.Errors = []string{"Check execution error: " + err.Error()}
+
+	details.Errors = []string{"Check execution error: " + exErr.Error()}
 	log.Debugln("Setting execution state of check", checkName, "to", details.OK, details.Errors)
 
 	// store the check state with the CRD

--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -44,7 +44,8 @@ var enableDaemonSetChecks = true       // do daemon set restart checking
 var enablePodRestartChecks = true      // do pod restart checking
 var enablePodStatusChecks = true       // do pod status checking
 var enableForceMaster bool             // force master mode - for debugging
-var enableDebug bool                   // enable deubug logging
+var enableDebug bool                   // enable debug logging
+var DSPauseContainerImageOverride string // specify an alternate location for the DSC pause container - see #114
 
 var kuberhealthy *Kuberhealthy
 
@@ -69,6 +70,7 @@ func init() {
 	flaggy.Bool(&enablePodStatusChecks, "", "podStatusChecks", "Set to false to disable pod lifecycle phase checking.")
 	flaggy.Bool(&enableForceMaster, "", "forceMaster", "Set to true to enable local testing, forced master mode.")
 	flaggy.Bool(&enableDebug, "d", "debug", "Set to true to enable debug.")
+	flaggy.String(&DSPauseContainerImageOverride,  "",  "dsPauseContainerImageOverride", "Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.")
 	flaggy.String(&podCheckNamespaces, "", "podCheckNamespaces", "The comma separated list of namespaces on which to check for pod status and restarts, if enabled.")
 	flaggy.Parse()
 
@@ -117,6 +119,11 @@ func main() {
 	// daemonset checking
 	if enableDaemonSetChecks {
 		dsc, err := daemonSet.New()
+		// allow the user to override the image used by the DSC - see #114
+		if len(DSPauseContainerImageOverride) > 0 {
+			log.Info("Setting DS pause container override image to:", DSPauseContainerImageOverride)
+			dsc.PauseContainerImage = DSPauseContainerImageOverride
+		}
 		if err != nil {
 			log.Fatalln("unable to create daemonset checker:", err)
 		}

--- a/deploy/kuberhealthy-and-prom-and-servicemonitor.yaml
+++ b/deploy/kuberhealthy-and-prom-and-servicemonitor.yaml
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/comcast/kuberhealthy:1.0.0
+      - image: quay.io/comcast/kuberhealthy:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy-and-prom-and-servicemonitor.yaml
+++ b/deploy/kuberhealthy-and-prom-and-servicemonitor.yaml
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/comcast/kuberhealthy:v1.0.1
+      - image: quay.io/comcast/kuberhealthy:v1.0.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy-and-prometheus.yaml
+++ b/deploy/kuberhealthy-and-prometheus.yaml
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/comcast/kuberhealthy:1.0.0
+      - image: quay.io/comcast/kuberhealthy:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy-and-prometheus.yaml
+++ b/deploy/kuberhealthy-and-prometheus.yaml
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/comcast/kuberhealthy:v1.0.1
+      - image: quay.io/comcast/kuberhealthy:v1.0.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -192,7 +192,7 @@ spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/comcast/kuberhealthy:v1.0.1
+      - image: quay.io/comcast/kuberhealthy:v1.0.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -212,6 +212,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: GRACE_PERIOD_TIMEOUT_SECONDS
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.terminationGracePeriodSeconds
         readinessProbe:
           failureThreshold: 3
           initialDelaySeconds: 2

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -192,7 +192,7 @@ spec:
       serviceAccountName: kuberhealthy
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/comcast/kuberhealthy:1.0.0
+      - image: quay.io/comcast/kuberhealthy:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -1,0 +1,16 @@
+Available flags for use in Kuberhealthy
+
+# Flags
+
+|Flag|Description|Optional|Default|
+|---|---|---|---|
+|`-kubecfg`|Absolute path to a kube config file.|Yes| `$HOME/.kube/config`|
+|`-listenAddress`|The port kuberhealthy will listen on.|Yes| `8080`|
+|`-componentStatusChecks`|Bool to enable/disable Kuberhealthy's [master component](https://kubernetes.io/docs/concepts/overview/components/#master-components) status [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#component-health).|Yes|`True`|
+|`-daemonsetChecks`|Bool to enable/disable Kuberhealthy's test daemon set [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#daemonset-deployment-and-termination).|Yes|`True`|
+|`-podRestartChecks`|Bool to enable/disable Kuberhealthy's pod restart check [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#excessive-pod-restarts).|Yes|`True`|
+|`-podStatusChecks`|Bool to enable/disable Kuberhealthy's pod status check [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#pod-status).|Yes|`True`|
+|`-forceMaster`|Bool to enable/disable election and force master mode.  Useful/Intended for local testing.|Yes|`False`|
+|`-debug`|Bool to enable/disable debug logging.|Yes|`False`|
+|`dsPauseContainerImageOverride`|Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.|Yes|`gcr.io/google_containers/pause:0.8.0`|
+|`podCheckNamespaces`|A comma separated list of namespaces in which to check for pod statuses and restart counts.|Yes|`kube-system`|

--- a/pkg/checks/daemonSet/daemonSet_test.go
+++ b/pkg/checks/daemonSet/daemonSet_test.go
@@ -36,6 +36,27 @@ func TestCleanupOrphans(t *testing.T) {
 	}
 }
 
+func TestPauseContainerOverride(t *testing.T) {
+	// verify that we are getting the expected default value from a new dsc
+	dsc, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dsc.PauseContainerImage != "gcr.io/google_containers/pause:0.8.0" {
+		t.Fatal("Default Pause Container Image is not set or an unexpected value, actual value:", dsc.PauseContainerImage)
+	}
+
+	dscO, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Silly, yes, but this mimics how the program is setting the override value
+	dscO.PauseContainerImage = "another-image-repo/pause:0.8.0"
+	if dscO.PauseContainerImage != "another-image-repo/pause:0.8.0" {
+		t.Fatal("Overridden Pause Container Image is not set or an unexpected value, actual value:", dscO.PauseContainerImage)
+	}
+}
+
 func TestGetAllDaemonsets(t *testing.T) {
 	checker, err := New()
 	if err != nil {


### PR DESCRIPTION
Addresses part of this issue: https://github.com/Comcast/kuberhealthy/issues/7
- Exposes the pod spec variable`terminationGracePeriodSeconds` as an environment variable `GRACE_PERIOD_TIMEOUT_SECONDS` to the container

Missing the other part of having this value be used as the shutdown grace period instead of the statically configured value.