### PR TITLE
[Issue-7] Expose gracePeriodTimeoutSeconds pod spec as env variable 

### DIFF
--- a/deploy/kuberhealthy-and-prom-and-servicemonitor.yaml
+++ b/deploy/kuberhealthy-and-prom-and-servicemonitor.yaml
@@ -244,6 +244,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: GRACE_PERIOD_TIMEOUT_SECONDS
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.terminationGracePeriodSeconds
         readinessProbe:
           failureThreshold: 3
           initialDelaySeconds: 2

--- a/deploy/kuberhealthy-and-prometheus.yaml
+++ b/deploy/kuberhealthy-and-prometheus.yaml
@@ -244,6 +244,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: GRACE_PERIOD_TIMEOUT_SECONDS
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.terminationGracePeriodSeconds
         readinessProbe:
           failureThreshold: 3
           initialDelaySeconds: 2

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -212,6 +212,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: GRACE_PERIOD_TIMEOUT_SECONDS
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.terminationGracePeriodSeconds
         readinessProbe:
           failureThreshold: 3
           initialDelaySeconds: 2


### PR DESCRIPTION
Addresses part of this issue: #7 

Exposes the pod spec variableterminationGracePeriodSeconds as an environment variable GRACE_PERIOD_TIMEOUT_SECONDS to the container

Missing the other part of having this value be used as the shutdown grace period instead of the statically configured value.