### PR TITLE
restore go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,37 @@
+module github.com/Comcast/kuberhealthy
+
+replace github.com/go-resty/resty => gopkg.in/resty.v1 v1.10.0
+
+replace google.golang.org/cloud => cloud.google.com/go v0.37.0
+
+replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.3.0
+
+require (
+	github.com/Pallinder/go-randomdata v1.1.0
+	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
+	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/influxdata/influxdb1-client v0.0.0-20190402204710-8ff2fc3824fc
+	github.com/integrii/flaggy v1.2.0
+	github.com/json-iterator/go v1.1.6 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.4.0
+	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/net v0.0.0-20190326090315-15845e8f865b // indirect
+	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+	k8s.io/api v0.0.0-20190222213804-5cb15d344471
+	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
+	k8s.io/client-go v10.0.0+incompatible
+	k8s.io/klog v0.2.0 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
+)


### PR DESCRIPTION
Restores `go.mod` back in project root after recent unstable branch removal and master/unstable merge.