### PR TITLE
Adding annotation to the daemonset pods to allow cluster-autoscaler t…

### DIFF
--- a/pkg/checks/daemonSet/daemonSet.go
+++ b/pkg/checks/daemonSet/daemonSet.go
@@ -84,6 +84,9 @@ func (dsc *Checker) generateDaemonSetSpec() {
 				"source":           "kuberhealthy",
 				"creatingInstance": dsc.hostname,
 			},
+			Annotations: map[string]string{
+				"cluster-autoscaler.kubernetes.io/safe-to-evict":	"true",
+			},
 		},
 		Spec: betaapiv1.DaemonSetSpec{
 			MinReadySeconds: 2,


### PR DESCRIPTION
…o consider them evictable during its scale-down logic.

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node

I found that kuberhealthy DS runs during a cluster-autoscaler scale-down evaluation could cause cluster autoscaler to consider that node unremovable.  On nodes that have pods that are slow to evict, or fast kuberhealthy DS runs, this could render an otherwise down-scaleable node unremovable.

Given a 5 minute scale-down timer, this node was considered removable and the eviction process began:
```
I0531 00:08:13.028879       1 static_autoscaler.go:294] ip-xx-xxx-xxx-xxx.us-west-2.compute.internal is unneeded since 2019-05-31 00:02:23.320651733 +0000 UTC duration 5m49.463273083s
```
But during the eviction process a kuberhealthy DSC was deployed and the scale down process was halted:
```
I0531 00:08:23.256785       1 cluster.go:92] Fast evaluation: node ip-xx-xxx-xxx-xxx.us-west-2.compute.internal cannot be removed: kuberhealthy/daemonset-test-kuberhealthy-565ffb89f-btwl5-1556582249-zsk5f is not replicated
```
And the node was subsequently ignored during the scale-down unremovable timer on later runs:

```
I0531 00:17:03.398900       1 scale_down.go:175] Scale-down calculation: ignoring 1 nodes, that were unremovable in the last 5m0s
```

This annotation is a quick fix to allow cluster-autoscaler to ignore kuberhealthy DS pods in its scale-down considerations.  In the future we may want to allow arbitrary annotations to be passed into the DS (among other things).