### PR TITLE
Ds toleration override

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -12,5 +12,6 @@ Available flags for use in Kuberhealthy
 |`-podStatusChecks`|Bool to enable/disable Kuberhealthy's pod status check [check](https://github.com/Comcast/kuberhealthy/blob/master/README.md#pod-status).|Yes|`True`|
 |`-forceMaster`|Bool to enable/disable election and force master mode.  Useful/Intended for local testing.|Yes|`False`|
 |`-debug`|Bool to enable/disable debug logging.|Yes|`False`|
-|`dsPauseContainerImageOverride`|Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.|Yes|`gcr.io/google_containers/pause:0.8.0`|
-|`podCheckNamespaces`|A comma separated list of namespaces in which to check for pod statuses and restart counts.|Yes|`kube-system`|
+|`-dsPauseContainerImageOverride`|Set an alternate image location for the pause container the daemon set checker uses for its daemon set configuration.|Yes|`gcr.io/google_containers/pause:0.8.0`|
+|`-tolerationOverride`|Specify a specific taint to tolerate and force DaemonSetChecker to tolerate only nodes with that taint. Use key,value,effect format, ex. node-role.kubernetes.io/master,,NoSchedule or dedicated,someteam,NoSchedule  Use the flag multiple times to add multiple tolerations.|Yes|All cluster taints are tolerated|
+|`-podCheckNamespaces`|A comma separated list of namespaces in which to check for pod statuses and restart counts.|Yes|`kube-system`|

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ k8s.io/api v0.0.0-20190222213804-5cb15d344471 h1:MzQGt8qWQCR+39kbYRd0uQqsvSidpYq
 k8s.io/api v0.0.0-20190222213804-5cb15d344471/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 h1:UYfHH+KEF88OTg+GojQUwFTNxbxwmoktLwutUzR0GPg=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUrIi34=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/checks/daemonSet/daemonSet.go
+++ b/pkg/checks/daemonSet/daemonSet.go
@@ -6,6 +6,7 @@ package daemonSet // import "github.com/Comcast/kuberhealthy/pkg/checks/daemonSe
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"os"
 	"strconv"
 	"strings"
@@ -38,7 +39,7 @@ type Checker struct {
 	DaemonSetName       string
 	PauseContainerImage string
 	hostname            string
-	tolerations         []apiv1.Toleration
+	Tolerations         []apiv1.Toleration
 	client              *kubernetes.Clientset
 }
 
@@ -54,7 +55,7 @@ func New() (*Checker, error) {
 		DaemonSetName:       daemonSetBaseName + "-" + hostname + "-" + strconv.Itoa(int(time.Now().Unix())),
 		hostname:            hostname,
 		PauseContainerImage: "gcr.io/google_containers/pause:0.8.0",
-		tolerations:         tolerations,
+		Tolerations:         tolerations,
 	}
 
 	return &testDS, nil
@@ -66,12 +67,15 @@ func (dsc *Checker) generateDaemonSetSpec() {
 	terminationGracePeriod := int64(1)
 	runAsUser := int64(1000)
 	log.Debug("Running daemon set as user 1000.")
-
-	// find all the taints in the cluster and create a toleration for each
 	var err error
-	dsc.tolerations, err = findAllUniqueTolerations(dsc.client)
-	if err != nil {
-		log.Warningln("Unable to generate list of pod scheduling tolerations", err)
+
+	// if a list of tolerations wasnt passed in, default to tolerating all taints
+	if len(dsc.Tolerations) == 0 {
+		// find all the taints in the cluster and create a toleration for each
+		dsc.Tolerations, err = findAllUniqueTolerations(dsc.client)
+		if err != nil {
+			log.Warningln("Unable to generate list of pod scheduling tolerations", err)
+		}
 	}
 
 	//create the DS object
@@ -130,8 +134,8 @@ func (dsc *Checker) generateDaemonSetSpec() {
 	}
 
 	// Add our generated list of tolerations or any the user input via flag
-	dsc.DaemonSet.Spec.Template.Spec.Tolerations = append(dsc.DaemonSet.Spec.Template.Spec.Tolerations, dsc.tolerations...)
 	log.Infoln("Deploying daemon set with tolerations: ", dsc.DaemonSet.Spec.Template.Spec.Tolerations)
+	dsc.DaemonSet.Spec.Template.Spec.Tolerations = append(dsc.DaemonSet.Spec.Template.Spec.Tolerations, dsc.Tolerations...)
 }
 
 // Name returns the name of this checker
@@ -208,6 +212,22 @@ func findAllUniqueTolerations(client *kubernetes.Clientset) ([]apiv1.Toleration,
 	}
 	log.Infoln("Found taints to tolerate:", uniqueTolerations)
 	return uniqueTolerations, nil
+}
+
+// ParseTolerationOverride parses a list of taints and returns them as a toleration object
+func (dsc *Checker) ParseTolerationOverride(taints []string) (tolerations []apiv1.Toleration, err error) {
+	for _, t := range taints {
+		s := strings.Split(t,",")
+		if len(s) != 3 {
+			return []apiv1.Toleration{}, errors.New("Unable to parse the passed in taint overrides - are they in the correct format?")
+		}
+		tolerations = append(tolerations, apiv1.Toleration{
+			Key:	s[0],
+			Value: 	s[1],
+			Effect:	apiv1.TaintEffect(s[2]),
+		})
+	}
+	return tolerations, err
 }
 
 // CurrentStatus returns the status of the check as of right now
@@ -716,10 +736,10 @@ func (dsc *Checker) getNodesMissingDSPod() ([]string, error) {
 
 	// populate a node status map. default status is "false", meaning there is
 	// not a pod deployed to that node.  We are only adding nodes that tolerate
-	// our list of dsc.tolerations
+	// our list of dsc.Tolerations
 	nodeStatuses := make(map[string]bool)
 	for _, n := range nodes.Items {
-		if taintsAreTolerated(n.Spec.Taints, dsc.tolerations) {
+		if taintsAreTolerated(n.Spec.Taints, dsc.Tolerations) {
 			nodeStatuses[n.Name] = false
 		}
 	}
@@ -739,7 +759,7 @@ func (dsc *Checker) getNodesMissingDSPod() ([]string, error) {
 				if nodeip.Type != "InternalIP" || nodeip.Address != pod.Status.HostIP {
 					continue
 				}
-				if taintsAreTolerated(node.Spec.Taints, dsc.tolerations) {
+				if taintsAreTolerated(node.Spec.Taints, dsc.Tolerations) {
 					nodeStatuses[node.Name] = true
 					break
 				}
@@ -893,3 +913,4 @@ func (dsc *Checker) getDaemonSetClient() v1beta1.DaemonSetInterface {
 	log.Debug("Creating Daemonset client.")
 	return dsc.client.ExtensionsV1beta1().DaemonSets(dsc.Namespace)
 }
+

--- a/pkg/checks/daemonSet/daemonSet_test.go
+++ b/pkg/checks/daemonSet/daemonSet_test.go
@@ -223,6 +223,7 @@ func TestParseTolerationOverride(t *testing.T) {
 		}
 		if !reflect.DeepEqual(actual, tt.expected) {
 			t.Error("Failure! - Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
+			continue
 		}
 		t.Log("Success! - Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
 	}

--- a/pkg/checks/daemonSet/daemonSet_test.go
+++ b/pkg/checks/daemonSet/daemonSet_test.go
@@ -190,7 +190,7 @@ func TestParseTolerationOverride(t *testing.T) {
 			[]apiv1.Toleration{
 			{
 				Key:    "node-role.kubernetes.io/master",
-				Value:  "asdf",
+				Value:  "",
 				Effect: apiv1.TaintEffect("NoSchedule"),
 			},
 			{

--- a/pkg/checks/daemonSet/daemonSet_test.go
+++ b/pkg/checks/daemonSet/daemonSet_test.go
@@ -190,7 +190,7 @@ func TestParseTolerationOverride(t *testing.T) {
 			[]apiv1.Toleration{
 			{
 				Key:    "node-role.kubernetes.io/master",
-				Value:  "",
+				Value:  "asdf",
 				Effect: apiv1.TaintEffect("NoSchedule"),
 			},
 			{
@@ -218,14 +218,12 @@ func TestParseTolerationOverride(t *testing.T) {
 
 	for _, tt := range taintTests{
 		actual, err := checker.ParseTolerationOverride(tt.input)
-		t.Log("Success! - Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
 		if err != nil && err.Error() != tt.err {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(actual, tt.expected) {
-			defer recover()
-			t.Error("Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
+			t.Error("Failure! - Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
 		}
-
+		t.Log("Success! - Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
 	}
 }

--- a/pkg/checks/daemonSet/daemonSet_test.go
+++ b/pkg/checks/daemonSet/daemonSet_test.go
@@ -223,6 +223,7 @@ func TestParseTolerationOverride(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(actual, tt.expected) {
+			defer recover()
 			t.Error("Input:", tt.input, "Expected:", tt.expected, "Received:", actual, "Error:", err)
 		}
 


### PR DESCRIPTION
Addresses #178 

Allows the user to manually specify the list of taints they wish the DS Checker pods to tolerate when scheduled.