### PR TITLE
expand mutexing to fight issue #181

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/Comcast/kuberhealthy/cmd/kuberhealthy
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 RUN go version
-#RUN go test -v -short -- --debug --forceMaster
+RUN go test -v -short -- --debug --forceMaster
 RUN go build -v -o kuberhealthy
 RUN mkdir /kuberhealthy
 RUN mv kuberhealthy /kuberhealthy/kuberhealthy

--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	k8s.io/klog v0.2.0 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ k8s.io/api v0.0.0-20190222213804-5cb15d344471 h1:MzQGt8qWQCR+39kbYRd0uQqsvSidpYq
 k8s.io/api v0.0.0-20190222213804-5cb15d344471/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 h1:UYfHH+KEF88OTg+GojQUwFTNxbxwmoktLwutUzR0GPg=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v10.0.0+incompatible h1:h3fciHPG0O5QEzATTFoRw/YGtDsU6pxrMrAhxiTtcq0=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/go.sum
+++ b/go.sum
@@ -71,7 +71,7 @@ k8s.io/api v0.0.0-20190222213804-5cb15d344471 h1:MzQGt8qWQCR+39kbYRd0uQqsvSidpYq
 k8s.io/api v0.0.0-20190222213804-5cb15d344471/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 h1:UYfHH+KEF88OTg+GojQUwFTNxbxwmoktLwutUzR0GPg=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v10.0.0+incompatible h1:h3fciHPG0O5QEzATTFoRw/YGtDsU6pxrMrAhxiTtcq0=
+k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUrIi34=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/khstatecrd/functions.go
+++ b/pkg/khstatecrd/functions.go
@@ -23,6 +23,8 @@ type KuberhealthyStateClient struct {
 }
 
 func (c *KuberhealthyStateClient) Create(state *KuberhealthyState, resource string) (*KuberhealthyState, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	result := KuberhealthyState{}
 	err := c.restClient.
 		Post().
@@ -35,6 +37,8 @@ func (c *KuberhealthyStateClient) Create(state *KuberhealthyState, resource stri
 }
 
 func (c *KuberhealthyStateClient) Delete(state *KuberhealthyState, resource string, name string) (*KuberhealthyState, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	result := KuberhealthyState{}
 	err := c.restClient.
 		Delete().
@@ -47,6 +51,8 @@ func (c *KuberhealthyStateClient) Delete(state *KuberhealthyState, resource stri
 }
 
 func (c *KuberhealthyStateClient) Update(state *KuberhealthyState, resource string, name string) (*KuberhealthyState, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	result := KuberhealthyState{}
 	//err := c.restClient.Verb("update").Namespace(c.ns).Resource(resource).Name(name).Do().Into(&result)
 	err := c.restClient.
@@ -61,6 +67,8 @@ func (c *KuberhealthyStateClient) Update(state *KuberhealthyState, resource stri
 }
 
 func (c *KuberhealthyStateClient) Get(opts metav1.GetOptions, resource string, name string) (*KuberhealthyState, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	result := KuberhealthyState{}
 	err := c.restClient.
 		Get().
@@ -74,6 +82,8 @@ func (c *KuberhealthyStateClient) Get(opts metav1.GetOptions, resource string, n
 }
 
 func (c *KuberhealthyStateClient) List(opts metav1.ListOptions, resource string) (*KuberhealthyStateList, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	result := KuberhealthyStateList{}
 	err := c.restClient.
 		Get().

--- a/pkg/khstatecrd/main.go
+++ b/pkg/khstatecrd/main.go
@@ -1,0 +1,10 @@
+package khstatecrd
+
+import (
+	"sync"
+)
+
+// mu works around a potential race with a map inside the kubernetes
+// api machinery which crashes when addKnownTypes and AddToGroupVersion are
+// both executing at the same time.
+var mu sync.Mutex

--- a/pkg/khstatecrd/register.go
+++ b/pkg/khstatecrd/register.go
@@ -12,8 +12,6 @@
 package khstatecrd
 
 import (
-	"sync"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -24,6 +22,9 @@ var SchemeGroupVersion schema.GroupVersion
 
 // ConfigureScheme configures the runtime scheme for use with CRD creation
 func ConfigureScheme(GroupName string, GroupVersion string) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 	var (
 		SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
@@ -32,14 +33,9 @@ func ConfigureScheme(GroupName string, GroupVersion string) {
 	AddToScheme(scheme.Scheme)
 }
 
-// knownTypesMu works around a potential race with a map inside the kubernetes
-// api machinery which crashes when addKnownTypes and AddToGroupVersion are
-// both executing at the same time.
-var knownTypesMu sync.Mutex
-
 func addKnownTypes(scheme *runtime.Scheme) error {
-	knownTypesMu.Lock()
-	defer knownTypesMu.Unlock()
+	mu.Lock()
+	defer mu.Unlock()
 
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&KuberhealthyState{},


### PR DESCRIPTION
This expands mutexting for the `khstatecrd` package greatly to fight concurrent map access problems deeper in kubernetes code as described in issue #181.