### PR TITLE
Check runtimeout fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
-IMAGE="quay.io/comcast/kuberhealthy"
-TAG="2.0.0alpha4"
+# IMAGE="quay.io/comcast/kuberhealthy"
+# TAG="2.0.0alpha4"
+
+# build:
+# 	docker build -t $(IMAGE):$(TAG) .
+
+# push:
+# 	docker push $(IMAGE):$(TAG)
+
+# buildExternalChecker:
+# 	docker build -t testexternalcheck:latest -f cmd/testExternalCheck/Dockerfile .
+
+VERSION="2.0.0alphajonny1"
+IMAGE="kuberhealthy:$(VERSION)"
+IMAGE_HOST="docker-proto.repo.theplatform.com"
 
 build:
-	docker build -t $(IMAGE):$(TAG) .
+	docker build -t $(IMAGE) .
 
-push:
-	docker push $(IMAGE):$(TAG)
+tag:
+	docker tag $(IMAGE) $(IMAGE_HOST)/$(IMAGE)
 
-buildExternalChecker:
-	docker build -t testexternalcheck:latest -f cmd/testExternalCheck/Dockerfile .
+push: tag
+	docker push $(IMAGE_HOST)/$(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,12 @@
-<<<<<<< HEAD
-# IMAGE="quay.io/comcast/kuberhealthy"
-# TAG="2.0.0alpha4"
-
-# build:
-# 	docker build -t $(IMAGE):$(TAG) .
-
-# push:
-# 	docker push $(IMAGE):$(TAG)
-
-# buildExternalChecker:
-# 	docker build -t testexternalcheck:latest -f cmd/testExternalCheck/Dockerfile .
-
-VERSION="2.0.0alphajonny1"
-IMAGE="kuberhealthy:$(VERSION)"
-IMAGE_HOST="docker-proto.repo.theplatform.com"
-=======
 IMAGE="quay.io/comcast/kuberhealthy"
 TAG="2.0.0alpha5"
->>>>>>> 61cabfdc9eaf0dc3bf51baf874778c64cfbf40d3
 
 build:
-	docker build -t $(IMAGE) .
+	docker build -t $(IMAGE):$(TAG) .
 
-tag:
-	docker tag $(IMAGE) $(IMAGE_HOST)/$(IMAGE)
+push:
+	docker push $(IMAGE):$(TAG)
 
-push: tag
-	docker push $(IMAGE_HOST)/$(IMAGE)
 buildExternalChecker:
 	docker build -t quay.io/comcast/testexternalcheck:latest -f cmd/testExternalCheck/Dockerfile .
 

--- a/cmd/kuberhealthy/kuberhealthy.go
+++ b/cmd/kuberhealthy/kuberhealthy.go
@@ -319,7 +319,7 @@ func (k *Kuberhealthy) addExternalChecks() error {
 		}
 
 		// parse the user specified timeout if present
-		c.RunInterval = khcheckcrd.DefaultTimeout
+		c.RunTimeout = khcheckcrd.DefaultTimeout
 		if len(i.Spec.Timeout) > 0 {
 			c.RunTimeout, err = time.ParseDuration(i.Spec.Timeout)
 			if err != nil {

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -191,6 +191,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - image: quay.io/comcast/kuberhealthy:2.0.0alpha2
+      # - image: docker-proto.repo.theplatform.com/kuberhealthy:2.0.0alphajonny1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -191,7 +191,6 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - image: quay.io/comcast/kuberhealthy:2.0.0alpha2
-      # - image: docker-proto.repo.theplatform.com/kuberhealthy:2.0.0alphajonny1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -190,7 +190,7 @@ spec:
                   - kuberhealthy
               topologyKey: "kubernetes.io/hostname"
       containers:
-      - image: quay.io/comcast/kuberhealthy:2.0.0alpha2
+      - image: quay.io/comcast/kuberhealthy:2.0.0alpha5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Check RunTimeout field was being improperly set to RunInterval when loading check CRDs