### PR TITLE
fix typo in podStatus checks

### DIFF
--- a/pkg/checks/podStatus/podStatus.go
+++ b/pkg/checks/podStatus/podStatus.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -165,7 +165,7 @@ func (psc *Checker) podFailures() (failures []string, err error) {
 		purge := true
 		for _, pod := range pods.Items {
 			for _, container := range pod.Status.ContainerStatuses {
-				currentlyFailedContainer := pod.Name + " ( " + container.Name + " )"
+				currentlyFailedContainer := pod.Name + " ( " + container.Name + " ) "
 				if currentlyFailedContainer == previouslyFailedContainer {
 					purge = false
 					break


### PR DESCRIPTION
`podStatus` checker was always purging the `previouslyFailedContainer` because of a typo in `currentlyFailedContainer` 