### PR TITLE
Remove package lists after updating in Dockerfile #8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN mkdir /kuberhealthy
 RUN mv kuberhealthy /kuberhealthy/kuberhealthy
 
 FROM golang
-RUN apt-get update
-RUN apt-get upgrade -y
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 RUN apt-get remove mercurial -y
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
Change to all the apt commands in the same layer and remove package lists/cache. Image size: 858MB. 