### PR TITLE
2.0.0 pod namespace env

### DIFF
--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -32,6 +32,10 @@ const KHReportingURL = "KH_REPORTING_URL"
 // can be de-duplicated on the server side.
 const KHRunUUID = "KH_RUN_UUID"
 
+// KHPodNamespace is the namespace variable used to tell external checks their namespace to perform
+// checks in.
+const KHPodNamespace = "KH_POD_NAMESPACE"
+
 // DefaultKuberhealthyReportingURL is the default location that external checks
 // are expected to report into.
 const DefaultKuberhealthyReportingURL = "http://kuberhealthy.kuberhealthy.svc.cluster.local/externalCheckStatus"
@@ -909,11 +913,15 @@ func (ext *Checker) configureUserPodSpec() error {
 			Name:  KHRunUUID,
 			Value: ext.currentCheckUUID,
 		},
+		{
+			Name:  KHPodNamespace,
+			Value: ext.Namespace,
+		},
 	}
 
 	// apply overwrite env vars on every container in the pod
 	for i := range ext.PodSpec.Containers {
-		ext.PodSpec.Containers[i].Env = resetInjectedContainerEnvVars(ext.PodSpec.Containers[i].Env, []string{KHReportingURL, KHRunUUID})
+		ext.PodSpec.Containers[i].Env = resetInjectedContainerEnvVars(ext.PodSpec.Containers[i].Env, []string{KHReportingURL, KHRunUUID, KHPodNamespace})
 		ext.PodSpec.Containers[i].Env = append(ext.PodSpec.Containers[i].Env, overwriteEnvVars...)
 	}
 


### PR DESCRIPTION
Addresses #249 

Resets the injected `KH_POD_NAMESPACE` env var.