### PR TITLE
Refactor pod restarts to only report success after full check run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ pushKIAMCheck:
 podRestarts: buildPodRestartsCheck pushPodRestartsCheck
 
 buildPodRestartsCheck:
-	docker build -t quay.io/comcast/pod-restarts-check:1.0.0 -f cmd/podRestartsCheck/Dockerfile .
+	docker build -t quay.io/comcast/pod-restarts-check:1.0.1 -f cmd/podRestartsCheck/Dockerfile .
 
 pushPodRestartsCheck:
-	docker push quay.io/comcast/pod-restarts-check:1.0.0
+	docker push quay.io/comcast/pod-restarts-check:1.0.1
 
 dnsStatus: buildDNSStatusCheck pushDNSStatusCheck
 

--- a/cmd/podRestartsCheck/main.go
+++ b/cmd/podRestartsCheck/main.go
@@ -129,6 +129,14 @@ func New() *Checker {
 func shutdownAfterDuration(duration time.Duration) {
 	time.Sleep(duration)
 
+	log.Infoln("Check run has completed successfully. Reporting check success to Kuberhealthy.")
+
+	err := checkclient.ReportSuccess()
+	if err != nil {
+		log.Println("Error reporting success to Kuberhealthy servers:", err)
+	}
+	log.Println("Successfully reported success to Kuberhealthy servers")
+
 	os.Exit(0)
 }
 
@@ -245,7 +253,7 @@ func (prc *Checker) removeBadPodRestarts(podName string) {
 func (prc *Checker) statusReporter() {
 	var err error
 
-	log.Infoln("Starting status reporter to send status reports to Kuberhealthy every minute")
+	log.Infoln("Starting status reporter to send status reports to Kuberhealthy if bad pod restarts are found")
 
 	// Start ticker for sending reports to Kuberhealthy
 	ticker := time.NewTicker(1 * time.Minute)
@@ -280,14 +288,6 @@ func (prc *Checker) statusReporter() {
 			continue
 		}
 
-		log.Println("No bad pod restarts found, reporting check success to Kuberhealthy servers")
-
-		err = checkclient.ReportSuccess()
-		if err != nil {
-			log.Println("Error reporting success to Kuberhealthy servers:", err)
-
-			continue
-		}
-		log.Println("Successfully reported success to Kuberhealthy servers")
+		log.Println("No bad pod with restarts found, starting next tick:", ticker.C)
 	}
 }

--- a/cmd/podRestartsCheck/main.go
+++ b/cmd/podRestartsCheck/main.go
@@ -131,11 +131,19 @@ func shutdownAfterDuration(duration time.Duration) {
 
 	log.Infoln("Check run has completed successfully. Reporting check success to Kuberhealthy.")
 
-	err := checkclient.ReportSuccess()
-	if err != nil {
-		log.Println("Error reporting success to Kuberhealthy servers:", err)
+	length := 0
+	BadPodRestarts.Range(func(_, _ interface{}) bool {
+		length++
+		return true
+	})
+
+	if length == 0 {
+		err := checkclient.ReportSuccess()
+		if err != nil {
+			log.Println("Error reporting success to Kuberhealthy servers:", err)
+		}
+		log.Println("Successfully reported success to Kuberhealthy servers")
 	}
-	log.Println("Successfully reported success to Kuberhealthy servers")
 
 	os.Exit(0)
 }

--- a/cmd/podRestartsCheck/podRestartsCheck.yaml
+++ b/cmd/podRestartsCheck/podRestartsCheck.yaml
@@ -15,7 +15,7 @@ spec:
             value: "55m"
           - name: MAX_FAILURES_ALLOWED
             value: "5"
-        image: quay.io/comcast/pod-restarts-check:1.0.0
+        image: quay.io/comcast/pod-restarts-check:1.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:

--- a/cmd/podRestartsCheck/podRestartsCheck.yaml
+++ b/cmd/podRestartsCheck/podRestartsCheck.yaml
@@ -22,3 +22,4 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+    restartPolicy: Never


### PR DESCRIPTION
Refactoring so the check only reports success at the end of the full run of the check.