### PR TITLE
fix DSPauseContainerImageOverride

### DIFF
--- a/cmd/daemonSetCheck/main.go
+++ b/cmd/daemonSetCheck/main.go
@@ -81,6 +81,8 @@ func init() {
 		log.Infoln("CHECK_POD_TIMEOUT environment variable has not been set. Using default Daemonset Checker timeout", defaultDSCheckTimeout)
 		dsCheckTimeout = defaultDSCheckTimeout
 	}
+	
+	DSPauseContainerImageOverride := os.Getenv("PAUSE_CONTAINER_IMAGE")
 
 	var err error
 	Timeout, err = time.ParseDuration(dsCheckTimeout)


### PR DESCRIPTION
`pause` image can't be overridden since `DSPauseContainerImageOverride` is not used.