### PR TITLE
Update DSCheck with new build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ pushDeploymentCheck:
 daemonset: buildDaemonsetCheck pushDaemonsetCheck
 
 buildDaemonsetCheck:
-	docker build -t quay.io/comcast/kh-daemonset-check:2.0.0 -f cmd/daemonSetCheck/Dockerfile .
+	docker build -t quay.io/comcast/kh-daemonset-check:2.0.1 -f cmd/daemonSetCheck/Dockerfile .
 
 pushDaemonsetCheck:
-	docker push quay.io/comcast/kh-daemonset-check:2.0.0
+	docker push quay.io/comcast/kh-daemonset-check:2.0.1
 
 kiamCheck: buildKIAMCheck pushKIAMCheck
 

--- a/cmd/daemonSetCheck/README.md
+++ b/cmd/daemonSetCheck/README.md
@@ -42,7 +42,7 @@ spec:
             # Make sure this value is less than the Kuberhealthy check timeout.
             # Default is set to 10m (10 minutes).
             value: "10m"
-        image: quay.io/comcast/kh-daemonset-check:2.0.0
+        image: quay.io/comcast/kh-daemonset-check:2.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:

--- a/cmd/daemonSetCheck/daemonSetCheck.yaml
+++ b/cmd/daemonSetCheck/daemonSetCheck.yaml
@@ -17,7 +17,7 @@ spec:
             # Make sure this value is less than the Kuberhealthy check timeout.
             # Default is set to 10m (10 minutes).
             value: "10m"
-        image: quay.io/comcast/kh-daemonset-check:2.0.0
+        image: quay.io/comcast/kh-daemonset-check:2.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:
@@ -49,7 +49,7 @@ rules:
   - apiGroups:
       - ""
       - extensions
-      - app
+      - apps
     resources:
       - daemonsets
       - pods

--- a/cmd/daemonSetCheck/main.go
+++ b/cmd/daemonSetCheck/main.go
@@ -25,17 +25,16 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	log "github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	apiv1 "k8s.io/api/core/v1"
-	betaapiv1 "k8s.io/api/extensions/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 
 	checkclient "github.com/Comcast/kuberhealthy/pkg/checks/external/checkClient"
 	"github.com/Comcast/kuberhealthy/pkg/kubeClient"
@@ -81,8 +80,8 @@ func init() {
 		log.Infoln("CHECK_POD_TIMEOUT environment variable has not been set. Using default Daemonset Checker timeout", defaultDSCheckTimeout)
 		dsCheckTimeout = defaultDSCheckTimeout
 	}
-	
-	DSPauseContainerImageOverride := os.Getenv("PAUSE_CONTAINER_IMAGE")
+
+	DSPauseContainerImageOverride = os.Getenv("PAUSE_CONTAINER_IMAGE")
 
 	var err error
 	Timeout, err = time.ParseDuration(dsCheckTimeout)
@@ -1099,7 +1098,7 @@ func (dsc *Checker) waitForPodRemoval() error {
 }
 
 // getDaemonSetClient returns a daemon set client, useful for interacting with daemonsets
-func (dsc *Checker) getDaemonSetClient() appsv1.DaemonSetInterface {
+func (dsc *Checker) getDaemonSetClient() v1.DaemonSetInterface {
 	log.Debug("Creating Daemonset client.")
-	return dsc.client.appsv1().DaemonSets(dsc.Namespace)
+	return dsc.client.AppsV1().DaemonSets(dsc.Namespace)
 }

--- a/cmd/daemonSetCheck/main_test.go
+++ b/cmd/daemonSetCheck/main_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Comcast/kuberhealthy/pkg/kubeClient"
 	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	betaapiv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Comcast/kuberhealthy/pkg/kubeClient"
 )
 
 func testSetup(clientNeeded bool) (*Checker, error) {
@@ -261,7 +262,7 @@ func makeDaemonsets(dsc *Checker, orphan bool) error {
 		hostname:      hostname,
 	}
 
-	testDS.DaemonSet = &betaapiv1.DaemonSet{
+	testDS.DaemonSet = &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testDS.DaemonSetName,
 			Labels: map[string]string{
@@ -271,7 +272,7 @@ func makeDaemonsets(dsc *Checker, orphan bool) error {
 				"checkRunTime": checkRunTime,
 			},
 		},
-		Spec: betaapiv1.DaemonSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":              testDS.DaemonSetName,

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: CHECK_POD_TIMEOUT
             value: "10m"
-        image: quay.io/comcast/kh-daemonset-check:2.0.0
+        image: quay.io/comcast/kh-daemonset-check:2.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:

--- a/deploy/kuberhealthy-prometheus-operator.yaml
+++ b/deploy/kuberhealthy-prometheus-operator.yaml
@@ -420,7 +420,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: CHECK_POD_TIMEOUT
             value: "10m"
-        image: quay.io/comcast/kh-daemonset-check:2.0.0
+        image: quay.io/comcast/kh-daemonset-check:2.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:

--- a/deploy/kuberhealthy-prometheus.yaml
+++ b/deploy/kuberhealthy-prometheus.yaml
@@ -410,7 +410,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: CHECK_POD_TIMEOUT
             value: "10m"
-        image: quay.io/comcast/kh-daemonset-check:2.0.0
+        image: quay.io/comcast/kh-daemonset-check:2.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -387,7 +387,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: CHECK_POD_TIMEOUT
             value: "10m"
-        image: quay.io/comcast/kh-daemonset-check:2.0.0
+        image: quay.io/comcast/kh-daemonset-check:2.0.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:


### PR DESCRIPTION
After the pr merge from #304 -- updating dscheck build image tag and updating all the specs to use this new build tag.

Also updates the role for daemonsets to use api group `apps` instead of `app`
Also includes using the right daemonset api endpoints (since we updated it in a last pr)
