### PR TITLE
add v2 to module now that tags are v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Comcast/kuberhealthy
+module github.com/Comcast/kuberhealthy/v2
 
 replace github.com/go-resty/resty => gopkg.in/resty.v1 v1.10.0
 


### PR DESCRIPTION
#307 continued.  need a `v2` at the end of the `go.mod` file.