### PR TITLE
apiGroup typo

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -48,7 +48,7 @@ rules:
   - apiGroups:
       - ""
       - extensions
-      - app
+      - apps
     resources:
       - daemonsets
       - pods


### PR DESCRIPTION
- fixes typo in helm chart that causes incorrect RBAC on daemonset checker