### PR TITLE
Add nodeSelector option for helm chart

### DIFF
--- a/deploy/helm/kuberhealthy/templates/check-reaper.yaml
+++ b/deploy/helm/kuberhealthy/templates/check-reaper.yaml
@@ -13,6 +13,10 @@ spec:
             - name: check-reaper
               image: {{ .Values.checkReaper.image.repository }}:{{ .Values.checkReaper.image.tag }}
               imagePullPolicy: IfNotPresent
+          {{- if .Values.checkReaper.nodeSelector }}
+          nodeSelector:
+{{- toYaml .Values.checkReaper.nodeSelector | nindent 12 }}
+          {{- end }}
           restartPolicy: OnFailure
           serviceAccountName: check-reaper
   concurrencyPolicy: Forbid

--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
           requests:
             cpu: {{ .Values.resources.requests.cpu }}
             memory: {{ .Values.resources.requests.memory }}
+      {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
 {{- if .Values.tolerations.master }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -24,6 +24,10 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+    {{- if .Values.check.daemonset.nodeSelector }}
+    nodeSelector:
+{{- toYaml .Values.check.daemonset.nodeSelector | nindent 6 }}
+    {{- end }}
     serviceAccountName: daemonset-khcheck
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         limits:
           cpu: 40m
       restartPolicy: Always
+    {{- if .Values.check.deployment.nodeSelector }}
+    nodeSelector:
+{{- toYaml .Values.check.deployment.nodeSelector | nindent 6 }}
+    {{- end }}
     serviceAccountName: deployment-sa
     terminationGracePeriodSeconds: 60
 ---

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
@@ -22,4 +22,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+    {{- if .Values.check.dnsInternal.nodeSelector }}
+    nodeSelector:
+{{- toYaml .Values.check.dnsInternal.nodeSelector | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -25,5 +25,9 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+    {{- if .Values.check.podRestarts.nodeSelector }}
+    nodeSelector:
+{{- toYaml .Values.check.podRestarts.nodeSelector | nindent 6 }}
+    {{- end }}
     restartPolicy: Never
 {{- end }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -23,4 +23,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+    {{- if .Values.check.podStatus.nodeSelector }}
+    nodeSelector:
+{{- toYaml .Values.check.podStatus.nodeSelector | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -30,6 +30,7 @@ deployment:
   maxSurge: 0
   maxUnavailable: 1
   imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   podAnnotations: {}
   command:
   - /app/kuberhealthy
@@ -58,28 +59,34 @@ check:
     image:
       repository: quay.io/comcast/kh-daemonset-check
       tag: 2.0.1
+    nodeSelector: {}
   deployment:
     enabled: true
     image:
       repository: quay.io/comcast/deployment-check
       tag: 1.1.0
+    nodeSelector: {}
   dnsInternal:
     enabled: true
     image:
       repository: quay.io/comcast/dns-status-check
       tag: 1.0.0
+    nodeSelector: {}
   podRestarts:
     enabled: false
     image:
       repository: quay.io/comcast/pod-restarts-check
       tag: 2.0.0
+    nodeSelector: {}
   podStatus:
     enabled: false
     image:
       repository: quay.io/comcast/pod-status-check
       tag: 1.0.1
+    nodeSelector: {}
 
 checkReaper:
   image:
     repository: quay.io/comcast/check-reaper
     tag: 1.0.0
+  nodeSelector: {}


### PR DESCRIPTION
Add nodeSelector to templates in the helm chart. This will enables users to better select what nodes can be scheduled for kuberhealthy without modifying the cluster-wide tolerations just for kuberhealthy. Default values for the nodeSelector have been left empty for those who don't care for this functionality.