### PR TITLE
Add envvar to customize reporting URL in helm chart

### DIFF
--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.deployment.env.KH_EXTERNAL_REPORTING_URL }}
+          - name: KH_EXTERNAL_REPORTING_URL
+            value: {{ .Values.deployment.env.KH_EXTERNAL_REPORTING_URL }}
+          {{- end }}
         readinessProbe:
           failureThreshold: 3
           initialDelaySeconds: 2

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -31,6 +31,7 @@ deployment:
   maxUnavailable: 1
   imagePullPolicy: IfNotPresent
   podAnnotations: {}
+  env: {}
   command:
   - /app/kuberhealthy
   # args:


### PR DESCRIPTION
The `KH_EXTERNAL_REPORTING_URL`, the service URL for the status page, can be customized based on the code here: https://github.com/Comcast/kuberhealthy/blob/3720681d1bd87604e95610a0d49241cc296738c9/cmd/kuberhealthy/main.go#L63

To be able to use this feature in the provided helm chart, this value should be able to be set in the values file. This PR adds just this environment variable to the Deployment container. Only this environment variable was added in this PR to constrain what environment variables can be set.