### PR TITLE
Fix dockerhub tags in all Makefile #358

### DIFF
--- a/cmd/ami-check/Makefile
+++ b/cmd/ami-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/ami-check:1.0.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/ami-check:1.0.2 -f Dockerfile ../../
 
 push:
-		docker push quay.io/comcast/ami-check:1.0.2
+		docker push kuberhealthy/ami-check:1.0.2

--- a/cmd/check-reaper/Makefile
+++ b/cmd/check-reaper/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/check-reaper:1.1.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/check-reaper:1.1.1 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/check-reaper:1.1.1
+	docker push kuberhealthy/check-reaper:1.1.1

--- a/cmd/daemonset-check/Makefile
+++ b/cmd/daemonset-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/daemonset-check:2.0.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/daemonset-check:2.0.1 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/daemonset-check:2.0.1
+	docker push kuberhealthy/daemonset-check:2.0.1

--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/deployment-check:1.1.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/deployment-check:1.1.2 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/deployment-check:1.1.2
+	docker push kuberhealthy/deployment-check:1.1.2

--- a/cmd/dns-resolution-check/Makefile
+++ b/cmd/dns-resolution-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/dns-resolution-check:1.0.0 -f Dockerfile ../../
+	docker build -t kuberhealthy/dns-resolution-check:1.0.0 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/dns-resolution-check:1.0.0
+	docker push kuberhealthy/dns-resolution-check:1.0.0

--- a/cmd/http-check/Makefile
+++ b/cmd/http-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/http-check:1.0.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/http-check:1.0.1 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/http-check:1.0.1
+	docker push kuberhealthy/http-check:1.0.1

--- a/cmd/http-content-check/Makefile
+++ b/cmd/http-content-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t jdowni000/http-content-check:v1.1.2 -f Dockerfile ../../
+	docker build -t kuberhelthy/http-content-check:v1.1.2 -f Dockerfile ../../
 
 push:
-	docker push jdowni000/http-content-check:v1.1.2
+	docker push kuberhelthy/http-content-check:v1.1.2

--- a/cmd/kiam-check/Makefile
+++ b/cmd/kiam-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/kiam-check:1.0.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/kiam-check:1.0.2 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/kiam-check:1.0.2
+	docker push kuberhealthy/kiam-check:1.0.2

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -1,11 +1,11 @@
-# IMAGE="quay.io/comcast/kuberhealthy"
+# IMAGE="kuberhealthy/kuberhealthy"
 # TAG="2.1.0"
 
 build:
-	docker build -t quay.io/comcast/kuberhealthy:2.1.0 -f Dockerfile ../../
+	docker build -t kuberhealthy/kuberhealthy:2.1.0 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/kuberhealthy:2.1.0
+	docker push kuberhealthy/kuberhealthy:2.1.0
 
 test:
 	POD_NAME="kuberhealthy-test" go test -run TestWebServer -v -args -- --debug --forceMaster

--- a/cmd/pod-restarts-check/Makefile
+++ b/cmd/pod-restarts-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/pod-restarts-check:2.0.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/pod-restarts-check:2.0.1 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/pod-restarts-check:2.0.1
+	docker push kuberhealthy/pod-restarts-check:2.0.1

--- a/cmd/pod-status-check/Makefile
+++ b/cmd/pod-status-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/pod-status-check:1.0.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/pod-status-check:1.0.2 -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/pod-status-check:1.0.2
+	docker push kuberhealthy/pod-status-check:1.0.2

--- a/cmd/test-external-check/Makefile
+++ b/cmd/test-external-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t quay.io/comcast/test-external-check:latest -f Dockerfile ../../
+	docker build -t kuberhealthy/test-external-check:latest -f Dockerfile ../../
 
 push:
-	docker push quay.io/comcast/test-external-check:latest
+	docker push kuberhealthy/test-external-check:latest


### PR DESCRIPTION
Fix #358 
I replaced docker hub tags in all Makefile `kuberhealthy/${IMAGE_NAME}` which pointing github acctions  following `.github/workflows/`