### PR TITLE
patch for deployment check's cleanUpOrphanedResources

### DIFF
--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/deployment-check:v1.2.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/deployment-check:v1.2.4 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/deployment-check:v1.2.2
+	docker push kuberhealthy/deployment-check:v1.2.4

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -10,7 +10,7 @@ spec:
   podSpec:
     containers:
     - name: deployment
-      image: kuberhealthy/deployment-check:v1.2.2
+      image: kuberhealthy/deployment-check:v1.2.4
       imagePullPolicy: IfNotPresent
       env:
         - name: CHECK_DEPLOYMENT_REPLICAS

--- a/cmd/deployment-check/run_check.go
+++ b/cmd/deployment-check/run_check.go
@@ -13,7 +13,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -36,7 +35,7 @@ func runDeploymentCheck() {
 	// TODO: Update this logic to unique services and deployments
 	// Delete all check resources (deployment & service) from this check that should not exist.
 	select {
-	case err := <-cleanUpOrphanedResources():
+	case err := <-cleanUpOrphanedResources(ctx):
 		// If the clean up completes with errors, we report those and stop the check cleanly.
 		if err != nil {
 			log.Errorln("error when cleaning up resources:", err)
@@ -276,45 +275,37 @@ func cleanUp(ctx context.Context) error {
 
 // cleanUpOrphanedResources cleans up previous deployment and services and ensures
 // a clean slate before beginning a deployment and service check.
-func cleanUpOrphanedResources() chan error {
+func cleanUpOrphanedResources(ctx context.Context) chan error {
 
 	cleanUpChan := make(chan error)
 
-	go func() {
+	go func(c context.Context) {
 		log.Infoln("Wiping all found orphaned resources belonging to this check.")
 
 		defer close(cleanUpChan)
 
-		// Check if an existing service exists.
-		serviceExists, err := findPreviousService()
+		svcExists, err := findPreviousService()
 		if err != nil {
-			cleanUpChan <- errors.New("error listing services: " + err.Error())
+			log.Warnln("Failed to find previous service:", err.Error())
+		}
+		if svcExists {
+			log.Infoln("Found previous service.")
 		}
 
-		// Clean it up if it exists.
-		if serviceExists {
-			err = cleanUpOrphanedService()
-			if err != nil {
-				cleanUpChan <- errors.New("error cleaning up old service: " + err.Error())
-			}
-		}
-
-		// Check if an existing deployment exists.
 		deploymentExists, err := findPreviousDeployment()
 		if err != nil {
-			cleanUpChan <- errors.New("error listing deployments: " + err.Error())
+			log.Warnln("Failed to find previous deployment:", err.Error())
 		}
-
-		// Clean it up if it exists.
 		if deploymentExists {
-			err = cleanUpOrphanedDeployment()
-			if err != nil {
-				cleanUpChan <- errors.New("error cleaning up old deployment: " + err.Error())
-			}
+			log.Infoln("Found previous deployment.")
 		}
 
-		cleanUpChan <- nil
-	}()
+		if svcExists || deploymentExists {
+			cleanUpChan <- cleanUp(c)
+		} else {
+			cleanUpChan <- nil
+		}
+	}(ctx)
 
 	return cleanUpChan
 }

--- a/cmd/deployment-check/service.go
+++ b/cmd/deployment-check/service.go
@@ -212,7 +212,7 @@ func deleteServiceAndWait(ctx context.Context) error {
 	// Send a delete on the service.
 	err := deleteService()
 	if err != nil {
-		log.Warningln("Error when running a delete on service:", checkServiceName)
+		log.Infoln("Could not delete service:", checkServiceName)
 	}
 
 	return <-deleteChan

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -66,8 +66,8 @@ check:
   deployment:
     enabled: true
     image:
-      repository: quay.io/comcast/deployment-check
-      tag: 1.1.1-patch
+      repository: kuberhealthy/deployment-check
+      tag: v1.2.3
     extraEnvs:
       CHECK_DEPLOYMENT_REPLICAS: "4"
       CHECK_DEPLOYMENT_ROLLING_UPDATE: "true"


### PR DESCRIPTION
A while back there was a patch for cleaning up check resources after the end of the check run -- this made the clean up processes different for both the before-check clean-up and post-check clean-up. This change makes sure that the before-check clean-up process respects context; additionally, it makes the before-check clean-up process mimic the post-check clean-up.