### PR TITLE
Move dl of gosec earlier in kuberheatlhy dockerfile

### DIFF
--- a/cmd/kuberhealthy/Dockerfile
+++ b/cmd/kuberhealthy/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.13 as builder
 LABEL LOCATION="git@github.com:Comcast/kuberhealthy.git"
 LABEL DESCRIPTION="Kuberhealthy - Check and expose kubernetes cluster health in detail."
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 2.0.0
 ADD ./ /go/src/github.com/Comcast/kuberhealthy/
 WORKDIR /go/src/github.com/Comcast/kuberhealthy/cmd/kuberhealthy
 ENV CGO_ENABLED=0
 RUN go version
-RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 2.0.0
 RUN gosec ./...
 #RUN go test -v -short -- --debug --forceMaster
 RUN go build -v -o kuberhealthy


### PR DESCRIPTION
This will increase the speed if you perform multiple builds.
Due to the container image caching, thanks to that we don't have to download gosec for each build.