### PR TITLE
go mod download for faster Dockerfile

### DIFF
--- a/cmd/ami-check/Dockerfile
+++ b/cmd/ami-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/ami-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user use
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/ami-check/Dockerfile
+++ b/cmd/ami-check/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /build/cmd/ami-check
 ENV CGO_ENABLED=0
 RUN go build -v
 RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user use
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/check-reaper/Dockerfile
+++ b/cmd/check-reaper/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/check-reaper
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/daemonset-check/Dockerfile
+++ b/cmd/daemonset-check/Dockerfile
@@ -1,10 +1,15 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/daemonset-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
+RUN chown user:user /build/cmd/daemonset-check/daemonset-check
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/daemonset-check/Dockerfile
+++ b/cmd/daemonset-check/Dockerfile
@@ -9,7 +9,6 @@ ENV CGO_ENABLED=0
 RUN go build -v
 RUN groupadd -g 999 user && \
     useradd -r -u 999 -g user user
-RUN chown user:user /build/cmd/daemonset-check/daemonset-check
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/deployment-check/Dockerfile
+++ b/cmd/deployment-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/deployment-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/http-check/Dockerfile
+++ b/cmd/http-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/http-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/http-content-check/Dockerfile
+++ b/cmd/http-content-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/http-content-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/kiam-check/Dockerfile
+++ b/cmd/kiam-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/kiam-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/kuberhealthy/Dockerfile
+++ b/cmd/kuberhealthy/Dockerfile
@@ -2,19 +2,22 @@ FROM golang:1.13 as builder
 LABEL LOCATION="git@github.com:Comcast/kuberhealthy.git"
 LABEL DESCRIPTION="Kuberhealthy - Check and expose kubernetes cluster health in detail."
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 2.0.0
-ADD ./ /go/src/github.com/Comcast/kuberhealthy/
+RUN mkdir /kuberhealthy
+
+WORKDIR /go/src/github.com/Comcast/kuberhealthy/
+ADD go.mod go.sum .
+RUN go mod download
+ADD ./ .
 WORKDIR /go/src/github.com/Comcast/kuberhealthy/cmd/kuberhealthy
 ENV CGO_ENABLED=0
-RUN go version
+# RUN go version
 RUN gosec ./...
 #RUN go test -v -short -- --debug --forceMaster
 RUN go build -v -o kuberhealthy
-RUN mkdir /kuberhealthy
 RUN mv kuberhealthy /kuberhealthy/kuberhealthy
 
 FROM golang:1.13
 RUN apt-get update && apt-get upgrade -y && apt-get remove mercurial -y && rm -rf /var/lib/apt/lists/*
-RUN mkdir /app
 WORKDIR /app
 COPY --from=builder /kuberhealthy/ /app
 

--- a/cmd/pod-restarts-check/Dockerfile
+++ b/cmd/pod-restarts-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/pod-restarts-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/pod-status-check/Dockerfile
+++ b/cmd/pod-status-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/pod-status-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/resource-quota-check/Dockerfile
+++ b/cmd/resource-quota-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/resource-quota-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user use
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user

--- a/cmd/test-external-check/Dockerfile
+++ b/cmd/test-external-check/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.13 AS builder
-RUN groupadd -g 999 user && \
-    useradd -r -u 999 -g user user
-COPY --chown=user:user . /build
+WORKDIR /build
+ADD go.mod go.sum /build/
+RUN go mod download
+
+COPY . /build
 WORKDIR /build/cmd/test-external-check
 ENV CGO_ENABLED=0
 RUN go build -v
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 USER user


### PR DESCRIPTION
go mod download will help to download all dependencies before coping over the code. This won't help allot in your local environment but if you run this in a CI/CD pipeline you will see a increase if you run the build multiple time at the same server due to docker caching.

Since go creates a bin and the COPY command sets the owner to the current user we don't have to do any chown until the bin is ready.
I assume that dockerhub should still be happy with the dockerfile since we are using USER in the final container.

I only did this update in one file, if you think this is a good idea i will do it in the rest of them.