### PR TITLE
provides a patch for the test check & moves the test check pod to use…

### DIFF
--- a/cmd/test-external-check/Makefile
+++ b/cmd/test-external-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/test-external-check:v1.2.0 -f Dockerfile ../../
+	docker build -t kuberhealthy/test-external-check:v1.2.1 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/test-external-check:v1.2.0
+	docker push kuberhealthy/test-external-check:v1.2.1

--- a/cmd/test-external-check/khcheck.yaml
+++ b/cmd/test-external-check/khcheck.yaml
@@ -17,7 +17,7 @@ spec:
             value: "false"
           - name: REPORT_DELAY
             value: "5s"
-        image: kuberhealthy/test-external-check:v1.1.0
+        image: kuberhealthy/test-external-check:v1.2.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:

--- a/cmd/test-external-check/main.go
+++ b/cmd/test-external-check/main.go
@@ -22,16 +22,21 @@ func init() {
 
 	// parse REPORT_FAILURE environment var
 	reportFailureStr := os.Getenv("REPORT_FAILURE")
-	reportFailure, err = strconv.ParseBool(reportFailureStr)
-	if err != nil {
-		log.Fatalln("Failed to parse REPORT_FAILURE env var:", err)
+	if len(reportFailureStr) != 0 {
+		reportFailure, err = strconv.ParseBool(reportFailureStr)
+		if err != nil {
+			log.Fatalln("Failed to parse REPORT_FAILURE env var:", err)
+		}
 	}
 
 	// parse REPORT_DELAY environment var
 	reportDelayStr := os.Getenv("REPORT_DELAY")
-	reportDelay, err = time.ParseDuration(reportDelayStr)
-	if err != nil {
-		log.Fatalln("Failed to parse REPORT_DELAY env var:", err)
+	reportDelay = time.Duration(time.Second * 5)
+	if len(reportDelayStr) != 0 {
+		reportDelay, err = time.ParseDuration(reportDelayStr)
+		if err != nil {
+			log.Fatalln("Failed to parse REPORT_DELAY env var:", err)
+		}
 	}
 }
 

--- a/pkg/checks/external/test/basicCheckerPod.yaml
+++ b/pkg/checks/external/test/basicCheckerPod.yaml
@@ -14,7 +14,7 @@ spec:
       - env:
           - name: "SOME_ENV_VAR"
             value: "12345"
-        image: integrii/kh-test-check
+        image: kuberhealthy/test-external-check:v1.2.1
         imagePullPolicy: IfNotPresent
         name: main
         resources:


### PR DESCRIPTION
… the same image

The test for the external package was still using the integrii/test-external-check -- this change addresses that by truing up the image used. This also provides a patch for parsing errors coming from the test check.