### PR TITLE
Security context additions to khchecks

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -33,9 +33,11 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+        {{- end}}
     {{- if .Values.check.daemonset.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.daemonset.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -9,9 +9,11 @@ spec:
   runInterval: 15m
   timeout: 12m
   podSpec:
+    {{- if .Values.securityContext.enabled }}
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- end}}
     containers:
       - env:
           - name: POD_NAMESPACE

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -9,6 +9,9 @@ spec:
   runInterval: 15m
   timeout: 12m
   podSpec:
+    securityContext:
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      fsGroup: {{ .Values.securityContext.fsGroup }}
     containers:
       - env:
           - name: POD_NAMESPACE
@@ -28,6 +31,9 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
     {{- if .Values.check.daemonset.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.daemonset.nodeSelector | nindent 6 }}
@@ -76,4 +82,3 @@ metadata:
   name: daemonset-khcheck
   namespace: {{ .Release.Namespace }}
 {{- end }}
-

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -9,9 +9,11 @@ spec:
   runInterval: 10m
   timeout: &deployment_check_timeout 15m
   podSpec:
+    {{- if .Values.securityContext.enabled }}
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- end}}
     containers:
     - name: deployment
       image: {{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}
@@ -30,8 +32,8 @@ spec:
         limits:
           cpu: 40m
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
       restartPolicy: Never
     {{- if .Values.check.deployment.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -8,17 +8,14 @@ metadata:
 spec:
   runInterval: 10m
   timeout: &deployment_check_timeout 15m
-  securityContext:
-    runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-    runAsUser: {{ .Values.securityContext.runAsUser }}
   podSpec:
+    securityContext:
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      fsGroup: {{ .Values.securityContext.fsGroup }}
     containers:
     - name: deployment
       image: {{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}
       imagePullPolicy: IfNotPresent
-      securityContext:
-        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
       env:
         - name: CHECK_TIME_LIMIT
           value: *deployment_check_timeout
@@ -32,6 +29,9 @@ spec:
           memory: 15Mi
         limits:
           cpu: 40m
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
       restartPolicy: Never
     {{- if .Values.check.deployment.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -35,6 +35,7 @@ spec:
       securityContext:
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
         readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+{{- end}}
       restartPolicy: Never
     {{- if .Values.check.deployment.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       imagePullPolicy: IfNotPresent
       securityContext:
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-        readOnlyRootFilesystem: {{ .Values.securityContext. }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
       env:
         - name: CHECK_TIME_LIMIT
           value: *deployment_check_timeout

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -8,11 +8,17 @@ metadata:
 spec:
   runInterval: 10m
   timeout: &deployment_check_timeout 15m
+  securityContext:
+    runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+    runAsUser: {{ .Values.securityContext.runAsUser }}
   podSpec:
     containers:
     - name: deployment
       image: {{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}
       imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+        readOnlyRootFilesystem: {{ .Values.securityContext. }}
       env:
         - name: CHECK_TIME_LIMIT
           value: *deployment_check_timeout
@@ -92,4 +98,3 @@ metadata:
   name: deployment-sa
   namespace: {{ .Release.Namespace }}
 {{- end }}
-

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -31,6 +31,7 @@ spec:
           memory: 15Mi
         limits:
           cpu: 40m
+{{- if .Values.securityContext.enabled }}
       securityContext:
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
         readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
@@ -9,6 +9,9 @@ spec:
   runInterval: 2m
   timeout: 15m
   podSpec:
+    securityContext:
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      fsGroup: {{ .Values.securityContext.fsGroup }}
     containers:
       - env:
           - name: CHECK_POD_TIMEOUT
@@ -24,6 +27,9 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
     {{- if .Values.check.dnsInternal.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.dnsInternal.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
@@ -9,9 +9,11 @@ spec:
   runInterval: 2m
   timeout: 15m
   podSpec:
+    {{- if .Values.securityContext.enabled }}
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- end}}
     containers:
       - env:
           - name: CHECK_POD_TIMEOUT

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns.yaml
@@ -29,9 +29,11 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+        {{- end }}
     {{- if .Values.check.dnsInternal.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.dnsInternal.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -8,9 +8,11 @@ spec:
   runInterval: 5m
   timeout: 10m
   podSpec:
+    {{- if .Values.securityContext.enabled }}
     securityContext:
-      allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-      readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- end}}
     containers:
       - env:
           - name: POD_NAMESPACE
@@ -31,8 +33,8 @@ spec:
             cpu: 10m
             memory: 50Mi
         securityContext:
-          runAsUser: {{ .Values.securityContext.runAsUser }}
-          fsGroup: {{ .Values.securityContext.fsGroup }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
     {{- if .Values.check.podRestarts.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.podRestarts.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -8,6 +8,9 @@ spec:
   runInterval: 5m
   timeout: 10m
   podSpec:
+    securityContext:
+      allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+      readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
     containers:
       - env:
           - name: POD_NAMESPACE
@@ -27,6 +30,9 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          fsGroup: {{ .Values.securityContext.fsGroup }}
     {{- if .Values.check.podRestarts.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.podRestarts.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -32,9 +32,11 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+        {{- end }}
     {{- if .Values.check.podRestarts.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.podRestarts.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -32,9 +32,11 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+        {{- end }}
     {{- if .Values.check.podStatus.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.podStatus.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -8,6 +8,9 @@ spec:
   runInterval: 5m
   timeout: 15m
   podSpec:
+    securityContext:
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      fsGroup: {{ .Values.securityContext.fsGroup }}
     containers:
       - env:
           - name: SKIP_DURATION
@@ -27,6 +30,9 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
     {{- if .Values.check.podStatus.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.podStatus.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -8,9 +8,11 @@ spec:
   runInterval: 5m
   timeout: 15m
   podSpec:
+    {{- if .Values.securityContext.enabled }}
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- end}}
     containers:
       - env:
           - name: SKIP_DURATION

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -39,7 +39,7 @@ deployment:
   # args:
 
 # When enabled equals to true, runAsUser and fsGroup will be
-# included to all khchecks as 999.
+# included to all khchecks as specified below.
 securityContext:
   enabled: true
   runAsNonRoot: true

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -38,7 +38,10 @@ deployment:
   - /app/kuberhealthy
   # args:
 
+# When enabled equals to true, runAsUser and fsGroup will be
+# included to all khchecks as 999.
 securityContext:
+  enabled: true
   runAsNonRoot: true
   runAsUser: 999
   fsGroup: 999
@@ -91,7 +94,7 @@ check:
       MAX_FAILURES_ALLOWED: "10"
     nodeSelector: {}
   podStatus:
-    enabled: true
+    enabled: false
     image:
       repository: kuberhealthy/pod-status-check
       tag: v1.2.2

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -42,6 +42,7 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 999
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 # Please remember that changing the service type to LoadBalancer
 # will expose Kuberhealthy to the internet, which could cause

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -41,6 +41,7 @@ deployment:
 securityContext:
   runAsNonRoot: true
   runAsUser: 999
+  fsGroup: 999
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 
@@ -90,7 +91,7 @@ check:
       MAX_FAILURES_ALLOWED: "10"
     nodeSelector: {}
   podStatus:
-    enabled: false
+    enabled: true
     image:
       repository: kuberhealthy/pod-status-check
       tag: v1.2.2

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -41,7 +41,7 @@ deployment:
 # When enabled equals to true, runAsUser and fsGroup will be
 # included to all khchecks as specified below.
 securityContext:
-  enabled: true
+  enabled: true # if enabled is set to false, securityContext settings will not be applied at all in checker pod custom resources
   runAsNonRoot: true
   runAsUser: 999
   fsGroup: 999


### PR DESCRIPTION
Need your thoughts on these changes to the helm charts.
1. Should user and fsgroup be 999 or 1000. I got a bit confused since there was already a security context value for the user.
2. Are the security context where they should be. 

 I added these fields into each of the khchecks pod spec:
```
  podSpec:
    securityContext:
      runAsUser: {{ .Values.securityContext.runAsUser }}
      fsGroup: {{ .Values.securityContext.fsGroup }}
```
and in the container spec:
```
      securityContext:
        runAsUser: {{ .Values.securityContext.runAsUser }}
        fsGroup: {{ .Values.securityContext.fsGroup }}
```
can be adjusted in the `values.yaml` file under:
```
securityContext:
  runAsNonRoot: true
  runAsUser: 999
  fsGroup: 999
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
```