### PR TITLE
Daemonst removal of hardcoded runAsUser

### DIFF
--- a/cmd/daemonset-check/main.go
+++ b/cmd/daemonset-check/main.go
@@ -37,11 +37,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	checkclient "github.com/Comcast/kuberhealthy/v2/pkg/checks/external/checkclient"
+	"github.com/Comcast/kuberhealthy/v2/pkg/checks/external/util"
 	"github.com/Comcast/kuberhealthy/v2/pkg/kubeClient"
 )
 
 const daemonSetBaseName = "ds-check"
 const defaultDSCheckTimeout = "10m"
+const defaultUser = int64(1000)
 
 var KubeConfigFile = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 var Namespace string
@@ -189,9 +191,14 @@ func (dsc *Checker) generateDaemonSetSpec() {
 
 	checkRunTime := strconv.Itoa(int(CheckRunTime))
 	terminationGracePeriod := int64(1)
-	runAsUser := int64(1000)
-	log.Debug("Running daemon set as user 1000.")
-	var err error
+
+	// Set the runAsUser
+	runAsUser := defaultUser
+	currentUser, err := util.GetCurrentUser(defaultUser)
+	if err != nil {
+		log.Infoln("runAsUser will be set to %v", currentUser)
+	}
+	runAsUser = currentUser
 
 	// if a list of tolerations wasnt passed in, default to tolerating all taints
 	if len(dsc.Tolerations) == 0 {

--- a/cmd/daemonset-check/main.go
+++ b/cmd/daemonset-check/main.go
@@ -196,8 +196,9 @@ func (dsc *Checker) generateDaemonSetSpec() {
 	runAsUser := defaultUser
 	currentUser, err := util.GetCurrentUser(defaultUser)
 	if err != nil {
-		log.Infoln("runAsUser will be set to %v", currentUser)
+		log.Infoln("Unable to get the current user id %v", err)
 	}
+	log.Infoln("runAsUser will be set to %v", currentUser)
 	runAsUser = currentUser
 
 	// if a list of tolerations wasnt passed in, default to tolerating all taints

--- a/pkg/checks/external/util/main.go
+++ b/pkg/checks/external/util/main.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"os"
+	"os/user"
+	"strconv"
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -42,4 +44,24 @@ func getKuberhealthyPod(client *kubernetes.Clientset, namespace, podName string)
 		return nil, err
 	}
 	return kHealthyPod, nil
+}
+
+// GetCurrentUser checks which os use that is running the app
+func GetCurrentUser(defaultUser int64) (int64, error) {
+	runAsUser := defaultUser
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return 0, err
+	}
+	intCurrentUser, err := strconv.ParseInt(currentUser.Uid, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	if intCurrentUser == 0 {
+		return defaultUser, nil
+	}
+	runAsUser = intCurrentUser
+	return runAsUser, nil
+
 }


### PR DESCRIPTION
The current runAsUser := 1000 creates issues when running in OCP.
If we assume that the user is set to none root in our checks
we can just grab that user ID and use that in the DS that is created.
Still have the default value in there if we for some reason can't find the id of the current user.

This will also work with runAsUser set in a standard k8s env or just
running it as a container since we have set 999 as the default user in
the containers.
