### PR TITLE
MOD:change string contain 'not found' to k8s error

### DIFF
--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -15,9 +15,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -609,7 +609,7 @@ func waitForDeploymentToDelete() chan bool {
 			_, err := client.AppsV1().Deployments(checkNamespace).Get(checkDeploymentName, metav1.GetOptions{})
 			if err != nil {
 				log.Debugln("error from Deployments().Get():", err.Error())
-				if strings.Contains(err.Error(), "not found") {
+				if k8sErrors.IsNotFound(err) {
 					log.Debugln("Deployment deleted.")
 					deleteChan <- true
 					return

--- a/cmd/deployment-check/service.go
+++ b/cmd/deployment-check/service.go
@@ -15,8 +15,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -393,7 +393,7 @@ func waitForServiceToDelete() chan bool {
 			_, err := client.CoreV1().Services(checkNamespace).Get(checkServiceName, metav1.GetOptions{})
 			if err != nil {
 				log.Debugln("error from Services().Get():", err.Error())
-				if strings.Contains(err.Error(), "not found") {
+				if k8sErrors.IsNotFound(err) {
 					log.Debugln("Service deleted.")
 					deleteChan <- true
 					return

--- a/cmd/kuberhealthy/crd.go
+++ b/cmd/kuberhealthy/crd.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"strings"
 	"time"
 
@@ -69,7 +70,7 @@ func ensureStateResourceExists(checkName string, checkNamespace string) error {
 	log.Debugln("Checking existence of custom resource:", name)
 	state, err := khStateClient.Get(metav1.GetOptions{}, stateCRDResource, name, checkNamespace)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if k8sErrors.IsNotFound(err) {
 			log.Infoln("Custom resource not found, creating resource:", name, " - ", err)
 			initialDetails := health.NewCheckDetails()
 			initialState := khstatecrd.NewKuberhealthyState(name, initialDetails)

--- a/cmd/pod-restarts-check/main.go
+++ b/cmd/pod-restarts-check/main.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -26,6 +25,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	checkclient "github.com/Comcast/kuberhealthy/v2/pkg/checks/external/checkclient"
 	"github.com/Comcast/kuberhealthy/v2/pkg/kubeClient"
@@ -191,7 +191,7 @@ func (prc *Checker) verifyBadPodRestartExists(podName string) error {
 
 	_, err := prc.client.CoreV1().Pods(prc.Namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if k8sErrors.IsNotFound(err) {
 			log.Infoln("Bad Pod:", podName, "no longer exists. Removing from bad pods map")
 			delete(prc.BadPods, podName)
 		} else {


### PR DESCRIPTION
change error in k8s api return `strings.Contains(err.Error(), "not found")` to `k8sErrors.IsNotFound(err)`
the `k8sErrors "k8s.io/apimachinery/pkg/api/errors"` can easily classify the cause of the error int k8s api.
