### PR TITLE
Deployment check patch4

### DIFF
--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/deployment-check:v1.3.4 -f Dockerfile ../../
+	docker build -t kuberhealthy/deployment-check:v1.4.0 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/deployment-check:v1.3.4
+	docker push kuberhealthy/deployment-check:v1.4.0

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -41,6 +41,10 @@ __IF ROLLING-UPDATE OPTION IS ENABLED__
   - `CHECK_NAMESPACE`: Namespace for the check (default=`kuberhealthy`).
   - `CHECK_DEPLOYMENT_REPLICAS`: Number of replicas in the deployment (default=`2`).
   - `CHECK_DEPLOYMENT_ROLLING_UPDATE`: Boolean to enable rolling-update (default=`false`).
+  - `CHECK_POD_CPU_REQUEST`: Check pod deployment CPU request value. Calculated in decimal SI units `(15 = 15m cpu)`.
+  - `CHECK_POD_CPU_LIMIT`: Check pod deployment CPU limit value. Calculated in decimal SI units `(75 = 75m cpu)`.
+  - `CHECK_POD_MEM_REQUEST`: Check pod deployment memory request value. Calculated in binary SI units `(20 * 1024^2 = 20Mi memory)`.
+  - `CHECK_POD_MEM_LIMIT`: Check pod deployment memory limit value. Calculated in binary SI units `(75 * 1024^2 = 75Mi memory)`.
   - `ADDITIONAL_ENV_VARS`: Comma separated list of `key=value` variables passed into the pod's containers.
   - `SHUTDOWN_GRACE_PERIOD`: Amount of time in seconds the shutdown will allow itself to clean up after an interrupt signal (default=`30s`).
   - `DEBUG`: Verbose debug logging.

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -40,7 +40,6 @@ __IF ROLLING-UPDATE OPTION IS ENABLED__
   - `CHECK_SERVICE_NAME`: Name for the check's service. (default=`deployment-svc`)
   - `CHECK_NAMESPACE`: Namespace for the check (default=`kuberhealthy`).
   - `CHECK_DEPLOYMENT_REPLICAS`: Number of replicas in the deployment (default=`2`).
-  - `CHECK_TIME_LIMIT`: Number of seconds the check will allow itself before timing out.
   - `CHECK_DEPLOYMENT_ROLLING_UPDATE`: Boolean to enable rolling-update (default=`false`).
   - `ADDITIONAL_ENV_VARS`: Comma separated list of `key=value` variables passed into the pod's containers.
   - `SHUTDOWN_GRACE_PERIOD`: Amount of time in seconds the shutdown will allow itself to clean up after an interrupt signal (default=`30s`).
@@ -58,7 +57,7 @@ metadata:
   namespace: kuberhealthy
 spec:
   runInterval: 10m
-  timeout: &deployment_check_timeout 15m
+  timeout: 15m
   podSpec:
     containers:
     - name: deployment
@@ -75,8 +74,6 @@ spec:
           value: "true"
         - name: ADDITIONAL_ENV_VARS
           value: "var1=foo,var2=bar"
-        - name: CHECK_TIME_LIMIT
-          value: *deployment_check_timeout
       resources:
         requests:
           cpu: 15m

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -65,7 +65,7 @@ spec:
   podSpec:
     containers:
     - name: deployment
-      image: kuberhealthy/deployment-check:v1.2.2
+      image: kuberhealthy/deployment-check:v1.4.0
       imagePullPolicy: IfNotPresent
       env:
         - name: CHECK_IMAGE

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kuberhealthy
 spec:
   runInterval: 10m
-  timeout: &deployment_check_timeout 15m
+  timeout: 15m
   podSpec:
     containers:
     - name: deployment
@@ -17,8 +17,6 @@ spec:
           value: "4"
         - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
           value: "true"
-        - name: CHECK_TIME_LIMIT
-          value: *deployment_check_timeout
       resources:
         requests:
           cpu: 25m

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -10,24 +10,12 @@ spec:
   podSpec:
     containers:
     - name: deployment
-      image: kuberhealthy/deployment-check:v1.2.4
+      image: kuberhealthy/deployment-check:v1.4.0
       imagePullPolicy: IfNotPresent
       env:
         - name: CHECK_DEPLOYMENT_REPLICAS
           value: "4"
         - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
-          value: "true"
-        - name: CHECK_SERVICE_ACCOUNT
-          value: default
-        - name: CHECK_POD_CPU_REQUEST
-          value: "10"
-        - name: CHECK_POD_CPU_LIMIT
-          value: "10"
-        - name: CHECK_POD_MEM_REQUEST
-          value: "10"
-        - name: CHECK_POD_MEM_LIMIT
-          value: "10"
-        - name: DEBUG
           value: "true"
       resources:
         requests:

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -17,6 +17,18 @@ spec:
           value: "4"
         - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
           value: "true"
+        - name: CHECK_SERVICE_ACCOUNT
+          value: default
+        - name: CHECK_POD_CPU_REQUEST
+          value: "10"
+        - name: CHECK_POD_CPU_LIMIT
+          value: "10"
+        - name: CHECK_POD_MEM_REQUEST
+          value: "10"
+        - name: CHECK_POD_MEM_LIMIT
+          value: "10"
+        - name: DEBUG
+          value: "true"
       resources:
         requests:
           cpu: 25m

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -256,13 +256,13 @@ func createContainerConfig(imageURL string) corev1.Container {
 	// Make maps for resources.
 	// Make and define a map for requests.
 	requests := make(map[corev1.ResourceName]resource.Quantity, 0)
-	requests[corev1.ResourceCPU] = *resource.NewMilliQuantity(defaultMillicoreRequest, resource.DecimalSI)
-	requests[corev1.ResourceMemory] = *resource.NewQuantity(defaultMemoryRequest, resource.BinarySI)
+	requests[corev1.ResourceCPU] = *resource.NewMilliQuantity(int64(millicoreRequest), resource.DecimalSI)
+	requests[corev1.ResourceMemory] = *resource.NewQuantity(int64(memoryRequest), resource.BinarySI)
 
 	// Make and define a map for limits.
 	limits := make(map[corev1.ResourceName]resource.Quantity, 0)
-	limits[corev1.ResourceCPU] = *resource.NewMilliQuantity(defaultMillicoreLimit, resource.DecimalSI)
-	limits[corev1.ResourceMemory] = *resource.NewQuantity(defaultMemoryLimit, resource.BinarySI)
+	limits[corev1.ResourceCPU] = *resource.NewMilliQuantity(int64(millicoreLimit), resource.DecimalSI)
+	limits[corev1.ResourceMemory] = *resource.NewQuantity(int64(memoryLimit), resource.BinarySI)
 
 	// Make and define a resource requirement struct.
 	resources := corev1.ResourceRequirements{

--- a/cmd/deployment-check/input.go
+++ b/cmd/deployment-check/input.go
@@ -116,6 +116,51 @@ func parseInputValues() {
 		log.Infoln("Parsed CHECK_DEPLOYMENT_REPLICAS:", checkDeploymentReplicas)
 	}
 
+	// Parse incoming check pod resource requests and limits
+	// Calculated in decimal SI units (15 = 15m cpu).
+	millicoreRequest = defaultMillicoreRequest
+	if len(millicoreRequestEnv) != 0 {
+		cpuRequest, err := strconv.ParseInt(millicoreRequestEnv, 10, 64)
+		if err != nil {
+			log.Fatalln("error occurred attempting to parse CHECK_POD_CPU_REQUEST:", err)
+		}
+		millicoreRequest = int(cpuRequest)
+		log.Infoln("Parsed CHECK_POD_CPU_REQUEST:", millicoreRequest)
+	}
+
+	// Calculated in decimal SI units (75 = 75m cpu).
+	millicoreLimit = defaultMillicoreLimit
+	if len(millicoreLimitEnv) != 0 {
+		cpuLimit, err := strconv.ParseInt(millicoreLimitEnv, 10, 64)
+		if err != nil {
+			log.Fatalln("error occurred attempting to parse CHECK_POD_CPU_LIMIT:", err)
+		}
+		millicoreLimit = int(cpuLimit)
+		log.Infoln("Parsed CHECK_POD_CPU_LIMIT:", millicoreLimit)
+	}
+
+	// Calculated in binary SI units (20 * 1024^2 = 20Mi memory).
+	memoryRequest = defaultMemoryRequest
+	if len(memoryRequestEnv) != 0 {
+		memRequest, err := strconv.ParseInt(memoryRequestEnv, 10, 64)
+		if err != nil {
+			log.Fatalln("error occurred attempting to parse CHECK_POD_MEM_REQUEST:", err)
+		}
+		memoryRequest = int(memRequest) * 1024 * 1024
+		log.Infoln("Parsed CHECK_POD_MEM_REQUEST:", memoryRequest)
+	}
+
+	// Calculated in binary SI units (75 * 1024^2 = 75Mi memory).
+	memoryLimit = defaultMemoryLimit
+	if len(memoryLimitEnv) != 0 {
+		memLimit, err := strconv.ParseInt(memoryLimitEnv, 10, 64)
+		if err != nil {
+			log.Fatalln("error occurred attempting to parse CHECK_POD_MEM_LIMIT:", err)
+		}
+		memoryLimit = int(memLimit) * 1024 * 1024
+		log.Infoln("Parsed CHECK_POD_MEM_LIMIT:", memoryLimit)
+	}
+
 	// Parse incoming check service account
 	checkServiceAccount = defaultCheckServieAccount
 	if len(checkServiceAccountEnv) != 0 {
@@ -137,8 +182,6 @@ func parseInputValues() {
 	}
 	if deadline > 0 {
 		log.Infoln("Parsed check deadline time from the environment:", deadline)
-		log.Infoln("Now:", time.Now().Unix())
-		log.Infoln("Deadline:", int64(deadline))
 		checkTimeLimit = time.Duration((int64(deadline) - time.Now().Unix()) * 1e9) // Multiply by 1,000,000,000 because that's how many nanoseconds are in a second
 	}
 

--- a/cmd/deployment-check/main.go
+++ b/cmd/deployment-check/main.go
@@ -66,9 +66,21 @@ var (
 	checkServiceAccountEnv = os.Getenv("CHECK_SERVICE_ACCOUNT")
 	checkServiceAccount    string
 
+	// Deployment pod resource requests and limits.
+	millicoreRequestEnv = os.Getenv("CHECK_POD_CPU_REQUEST")
+	millicoreRequest    int
+
+	millicoreLimitEnv = os.Getenv("CHECK_POD_CPU_LIMIT")
+	millicoreLimit    int
+
+	memoryRequestEnv = os.Getenv("CHECK_POD_MEM_REQUEST")
+	memoryRequest    int
+
+	memoryLimitEnv = os.Getenv("CHECK_POD_MEM_LIMIT")
+	memoryLimit    int
+
 	// Check time limit.
-	checkTimeLimitEnv = os.Getenv("CHECK_TIME_LIMIT")
-	checkTimeLimit    time.Duration
+	checkTimeLimit time.Duration
 
 	// Boolean value if a rolling-update is requested.
 	rollingUpdateEnv = os.Getenv("CHECK_DEPLOYMENT_ROLLING_UPDATE")

--- a/cmd/deployment-check/run_check.go
+++ b/cmd/deployment-check/run_check.go
@@ -118,9 +118,7 @@ func runDeploymentCheck() {
 	// hostname := getServiceLoadBalancerHostname()
 	ipAddress := getServiceClusterIP()
 	if len(ipAddress) == 0 {
-		// if len(hostname) == 0 {
 		// If the retrieved address is empty or nil, clean up and exit.
-		// log.Infoln("Cleaning up check and exiting because the load balancer hostname is nil.")
 		log.Infoln("Cleaning up check and exiting because the cluster IP is nil: ", ipAddress)
 		errorReport := []string{} // Make a slice for errors here, because there can be more than 1 error.
 		// Clean up the check. A deployment was brought up, but no ingress was created.

--- a/cmd/deployment-check/run_check.go
+++ b/cmd/deployment-check/run_check.go
@@ -46,10 +46,11 @@ func runDeploymentCheck() {
 	case <-ctx.Done():
 		// If there is a cancellation interrupt signal.
 		log.Infoln("Canceling cleanup and shutting down from interrupt.")
+		reportErrorsToKuberhealthy([]string{"failed to perform pre-check cleanup in time"})
 		return
 	case <-cleanupTimeout:
 		// If the clean up took too long, exit.
-		reportErrorsToKuberhealthy([]string{"failed to clean up resources in time"})
+		reportErrorsToKuberhealthy([]string{"failed to perform pre-check cleanup in time"})
 		return
 	}
 
@@ -72,6 +73,7 @@ func runDeploymentCheck() {
 	case <-ctx.Done():
 		// If there is a cancellation interrupt signal.
 		log.Infoln("Cancelling check and shutting down due to interrupt.")
+		reportErrorsToKuberhealthy([]string{"failed to create deployment within timeout"})
 		return
 	case <-runTimeout:
 		// If creating a deployment took too long, exit.
@@ -104,10 +106,11 @@ func runDeploymentCheck() {
 	case <-ctx.Done():
 		// If there is a cancellation interrupt signal, exit.
 		log.Infoln("Cancelling check and shutting down due to interrupt.")
+		reportErrorsToKuberhealthy([]string{"failed to create service within timeout"})
 		return
 	case <-runTimeout:
 		// If creating a service took too long, exit.
-		reportErrorsToKuberhealthy([]string{"failed to create deployment within timeout"})
+		reportErrorsToKuberhealthy([]string{"failed to create service within timeout"})
 		return
 	}
 
@@ -155,10 +158,11 @@ func runDeploymentCheck() {
 	case <-ctx.Done():
 		// If there is a cancellation interrupt signal, exit.
 		log.Infoln("Cancelling check and shutting down due to interrupt.")
+		reportErrorsToKuberhealthy([]string{"failed to make http request to the deployment service within timeout"})
 		return
 	case <-runTimeout:
 		// If requests to the hostname endpoint for a status code of 200 took too long, exit.
-		reportErrorsToKuberhealthy([]string{"failed to create deployment within timeout"})
+		reportErrorsToKuberhealthy([]string{"failed to make http request to the deployment service within timeout"})
 		return
 	}
 
@@ -192,6 +196,7 @@ func runDeploymentCheck() {
 		case <-ctx.Done():
 			// If there is a cancellation interrupt signal.
 			log.Infoln("Cancelling check and shutting down due to interrupt.")
+			reportErrorsToKuberhealthy([]string{"failed to update deployment within timeout"})
 			return
 		case <-runTimeout:
 			// If creating a deployment took too long, exit.
@@ -219,10 +224,11 @@ func runDeploymentCheck() {
 		case <-ctx.Done():
 			// If there is a cancellation interrupt signal, exit.
 			log.Infoln("Cancelling check and shutting down due to interrupt.")
+			reportErrorsToKuberhealthy([]string{"failed to make http request to the deployment service within timeout"})
 			return
 		case <-runTimeout:
 			// If requests to the hostname endpoint for a status code of 200 took too long, exit.
-			reportErrorsToKuberhealthy([]string{"failed to create deployment within timeout"})
+			reportErrorsToKuberhealthy([]string{"failed to make http request to the deployment service within timeout"})
 			return
 		}
 	}

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -14,8 +14,6 @@ spec:
       image: {{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}
       imagePullPolicy: IfNotPresent
       env:
-        - name: CHECK_TIME_LIMIT
-          value: {{ .Values.check.deployment.timeout }}
 {{- range $key, $value := .Values.check.deployment.extraEnvs }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -71,7 +71,7 @@ check:
     timeout: 15m
     image:
       repository: kuberhealthy/deployment-check
-      tag: v1.3.4
+      tag: v1.4.0
     extraEnvs:
       CHECK_DEPLOYMENT_REPLICAS: "4"
       CHECK_DEPLOYMENT_ROLLING_UPDATE: "true"

--- a/pkg/checks/external/checkclient/main.go
+++ b/pkg/checks/external/checkclient/main.go
@@ -107,3 +107,16 @@ func getKuberhealthyURL() (string, error) {
 
 	return reportingURL, nil
 }
+
+// GetDeadline fetches the KH_CHECK_RUN_DEADLINE environment variable and returns it.
+// Checks are given up to the deadline to complete their check runs.
+func GetDeadline() (string, error) {
+	unixDeadline := os.Getenv(external.KHDeadline)
+
+	if len(unixDeadline) < 1 {
+		writeLog("ERROR: kuberhealthy check deadline from environment variable", external.KHDeadline, "was blank")
+		return "", fmt.Errorf("fetched %s environment variable but it was blank", external.KHDeadline)
+	}
+
+	return unixDeadline, nil
+}


### PR DESCRIPTION
This change addresses various things:

- Respect race conditions when checker pod starts up by utilizing KH_CHECK_RUN_DEADLINE -- described in #380 and #386 
- Add a function to pull KH_CHECK_RUN_DEADLINE from the environment variables
- Report back to Kuberhealthy on the current state of the check when given interrupt / kill signal
- Respect custom resource requests and limits on the deployment pods that are brought up during the deployment check described in #395 (adds `CHECK_POD_CPU_REQUEST`, `CHECK_POD_CPU_LIMIT`, `CHECK_POD_MEM_REQUEST`, `CHECK_POD_MEM_LIMIT`)