### PR TITLE
FIX: fix the bud -> when check pod pending delete it, main process blocked && format project

### DIFF
--- a/cmd/check-reaper/main.go
+++ b/cmd/check-reaper/main.go
@@ -20,7 +20,7 @@ var ReapCheckerPods map[string]v1.Pod
 var MaxPodsThreshold = 4
 var Namespace string
 
-func init(){
+func init() {
 	Namespace = os.Getenv("SINGLE_NAMESPACE")
 	if len(Namespace) == 0 {
 		log.Infoln("Single namespace not specified, running check reaper across all namespaces")

--- a/cmd/deployment-check/deployment_test.go
+++ b/cmd/deployment-check/deployment_test.go
@@ -23,7 +23,7 @@ func TestCreateContainerConfig(t *testing.T) {
 
 		if len(containerConfig.ImagePullPolicy) == 0 {
 			t.Fatalf("nil image pull policy: %s", containerConfig.ImagePullPolicy)
-		}	
+		}
 
 		if len(containerConfig.Ports) == 0 {
 			t.Fatalf("no ports given for container: found %d ports\n", len(containerConfig.Ports))
@@ -51,7 +51,7 @@ func TestCreateDeploymentConfig(t *testing.T) {
 		if len(deploymentConfig.ObjectMeta.Namespace) == 0 {
 			t.Fatalf("nil deployment object meta namespace: %s\n", deploymentConfig.ObjectMeta.Namespace)
 		}
-		
+
 		reps := int32(1)
 		if *deploymentConfig.Spec.Replicas < reps {
 			t.Fatalf("deployment config was created with less than 1 replica: %d", deploymentConfig.Spec.Replicas)

--- a/cmd/kuberhealthy/main_test.go
+++ b/cmd/kuberhealthy/main_test.go
@@ -4,8 +4,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func init(){
+func init() {
 	// tests always run with debug logging
 	log.SetLevel(log.DebugLevel)
 }
-

--- a/cmd/pod-restarts-check/main.go
+++ b/cmd/pod-restarts-check/main.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	checkclient "github.com/Comcast/kuberhealthy/v2/pkg/checks/external/checkclient"
 	"github.com/Comcast/kuberhealthy/v2/pkg/kubeClient"

--- a/cmd/pod-restarts-check/main_test.go
+++ b/cmd/pod-restarts-check/main_test.go
@@ -13,15 +13,15 @@ func pod(podName string, containerName string, restartCount int32) *v1.Pod {
 	var pod = v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
 			Namespace: "test-namespace",
-			Name: podName,
+			Name:      podName,
 		},
 		Spec: v1.PodSpec{},
 		Status: v1.PodStatus{
 			Reason: "Ready",
 			ContainerStatuses: []v1.ContainerStatus{
 				{Name: containerName,
-				Ready: true,
-				RestartCount: restartCount},
+					Ready:        true,
+					RestartCount: restartCount},
 			},
 		},
 	}
@@ -45,8 +45,8 @@ func TestAddPodRestartCount(t *testing.T) {
 
 	var testCase = struct {
 		description string
-		pod v1.Pod
-		expected map[string]map[string]int32
+		pod         v1.Pod
+		expected    map[string]map[string]int32
 	}{"Pod: test-pod, container: container-name, restart count: 5",
 		*pod("test-pod", "container-name", 5),
 		expectedRestartObservations}
@@ -70,7 +70,7 @@ func TestCheckBadPodRestarts(t *testing.T) {
 
 	var testCases = []struct {
 		description string
-		pod v1.Pod
+		pod         v1.Pod
 	}{
 		{
 			"Bad pod with more than max restarts",
@@ -109,7 +109,7 @@ func TestRemoveBadPodRestarts(t *testing.T) {
 
 	var testCases = []struct {
 		description string
-		pod v1.Pod
+		pod         v1.Pod
 	}{
 		{"Remove deleted pod from BadPodRestarts", *pod("removed-bad-pod", "removed-bad-container", 3)},
 		{"Don't remove pod from BadPodRestarts", *pod("bad-test-pod", "bad-test-container", 8)},

--- a/pkg/health/checkDetails.go
+++ b/pkg/health/checkDetails.go
@@ -17,7 +17,7 @@ import "time"
 type CheckDetails struct {
 	OK               bool
 	Errors           []string
-	RunDuration		 string
+	RunDuration      string
 	Namespace        string
 	LastRun          time.Time // the time the check last was last run
 	AuthoritativePod string    // the pod that last ran the check

--- a/pkg/khcheckcrd/functions_test.go
+++ b/pkg/khcheckcrd/functions_test.go
@@ -56,7 +56,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkDetails := NewKuberhealthyCheck(testCheckName, defaultNamespace, NewCheckConfig(time.Second,v1.PodSpec{}))
+	checkDetails := NewKuberhealthyCheck(testCheckName, defaultNamespace, NewCheckConfig(time.Second, v1.PodSpec{}))
 	result, err := client.Create(&checkDetails, resource, defaultNamespace)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
for issue #436 
fix the main process blocked bug.

The following are the detailed triggering reasons
- if the watch for khcheck cr any change, we'll `k.RestartChecks()`
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/cmd/kuberhealthy/kuberhealthy.go#L183-L199

- but in `k.StopChecks()` it will wait for `c.Shutdown()`
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/cmd/kuberhealthy/kuberhealthy.go#L115-L140

- int `c.Shutdown()`,trigger `ext.shutdownCTXFunc()` , and wait for `ext.wg.Wait()`
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L1216-L1240

- if we run a check, the `func (ext *Checker) RunOnce() error {}` it will waitForPodStart
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L619-L631

- the `ext.waitForPodStart` will run `ext.wg.Add(1)`
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L938-L1015

but ,in the waitForPodStart() function, if the pod deleted before `p.Status.Phase == apiv1.PodRunning || p.Status.Phase == apiv1.PodFailed || p.Status.Phase == apiv1.PodSucceeded`, the `for e := range watcher.ResultChan()` for loop will blocked.

so the `k.StopChecks()` will blocked, the `k.RestartChecks()` will blocked.
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/cmd/kuberhealthy/kuberhealthy.go#L183-L199

we can watch for delete pod event here and return err.

I also saw a method `func (ext *Checker) watchForCheckerPodShutdown(shutdownEventNotifyC chan struct{}, ctx context.Context)`
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L597-L599
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L374-L415
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L460-L500

but the `func (ext *Checker) waitForDeletedEvent(eventsIn <-chan watch.Event, sawRemovalChan chan struct{}, stoppedChan chan struct{})` do nothing.
https://github.com/Comcast/kuberhealthy/blob/3309e2b740e635f00bcd257c5ba0be5209ddaed2/pkg/checks/external/main.go#L469-L494

if a check pod create, it's status will be `pending` first, and the `waitForDeletedEvent` will return if it's status be 'pending', because it's a `watch.Modified`, the `case watch.Deleted:` never run. Because we can't delete a pod before it pending.

I haven't carefully observed whether this method has any other effect, so I didn't modify the logic here, or left it as it is. Just in `waitForPodStart()` watch for the delete event.
