### PR TITLE
removed kh from http-content-check in spec

### DIFF
--- a/cmd/http-content-check/README.md
+++ b/cmd/http-content-check/README.md
@@ -11,7 +11,7 @@ You can specify the string to look for with the `TARGET_STRING` environment vari
   apiVersion: comcast.github.io/v1
   kind: KuberhealthyCheck
   metadata:
-    name: kh-http-content-check
+    name: http-content-check
   spec:
     runInterval: 60s # The interval that Kuberhealthy will run your check on
     timeout: 2m # After this much time, Kuberhealthy will kill your check and consider it "failed"

--- a/cmd/http-content-check/http-content-check.yaml
+++ b/cmd/http-content-check/http-content-check.yaml
@@ -1,7 +1,7 @@
 apiVersion: comcast.github.io/v1
 kind: KuberhealthyCheck
 metadata:
-  name: kh-http-content-check
+  name: http-content-check
 spec:
   runInterval: 60s # The interval that Kuberhealthy will run your check on
   timeout: 2m # After this much time, Kuberhealthy will kill your check and consider it "failed"


### PR DESCRIPTION
updated `README.MD` and `http-content-check.yaml` file to remove the kh prefix before the name for standardization