### PR TITLE
kuberhealthy: make kuberhealthy namespace aware

### DIFF
--- a/cmd/kuberhealthy/kuberhealthy.go
+++ b/cmd/kuberhealthy/kuberhealthy.go
@@ -226,13 +226,13 @@ func (k *Kuberhealthy) khStateResourceReaper(ctx context.Context) {
 func (k *Kuberhealthy) reapKHStateResources() error {
 
 	// list all khStates in the cluster
-	khStates, err := khStateClient.List(metav1.ListOptions{}, stateCRDResource, "")
+	khStates, err := khStateClient.List(metav1.ListOptions{}, stateCRDResource, listenNamespace)
 	if err != nil {
 		return fmt.Errorf("khState reaper: error listing khStates for reaping: %w", err)
 	}
 
 	// list all khChecks
-	khChecks, err := khCheckClient.List(metav1.ListOptions{}, checkCRDResource, "")
+	khChecks, err := khCheckClient.List(metav1.ListOptions{}, checkCRDResource, listenNamespace)
 	if err != nil {
 		return fmt.Errorf("khState reaper: error listing khChecks for khState reaping: %w", err)
 	}
@@ -279,7 +279,8 @@ func (k *Kuberhealthy) watchForKHCheckChanges(ctx context.Context, c chan struct
 		time.Sleep(time.Second)
 
 		// start a watch on khcheck resources
-		watcher, err := khCheckClient.Watch(metav1.ListOptions{})
+		watcher, err := khCheckClient.Watch(metav1.ListOptions{}, checkCRDResource, listenNamespace)
+
 		if err != nil {
 			log.Errorln("error watching khcheck objects:", err)
 			continue
@@ -343,7 +344,7 @@ func (k *Kuberhealthy) monitorExternalChecks(ctx context.Context, notify chan st
 		log.Debugln("Change notification received. Scanning for external check changes...")
 
 		// fetch all khcheck resources from all namespaces
-		l, err := khCheckClient.List(metav1.ListOptions{}, checkCRDResource, "")
+		l, err := khCheckClient.List(metav1.ListOptions{}, checkCRDResource, listenNamespace)
 		if err != nil {
 			log.Errorln("Error listing check configuration resources", err)
 			continue
@@ -442,7 +443,7 @@ func (k *Kuberhealthy) addExternalChecks() error {
 	log.Debugln("Fetching khcheck configurations...")
 
 	// list all checks from all namespaces
-	l, err := khCheckClient.List(metav1.ListOptions{}, checkCRDResource, "")
+	l, err := khCheckClient.List(metav1.ListOptions{}, checkCRDResource, listenNamespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -34,13 +34,14 @@ import (
 )
 
 // status represents the current Kuberhealthy OK:Error state
-var kubeConfigFile = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+var kubeConfigFile = filepath.Join(os.Getenv("KUBECONFIG"))
 var listenAddress = ":8080"
 var podCheckNamespaces = "kube-system"
 var podNamespace = os.Getenv("POD_NAMESPACE")
 var isMaster bool                  // indicates this instance is the master and should be running checks
 var upcomingMasterState bool       // the upcoming master state on next interval
 var lastMasterChangeTime time.Time // indicates the last time a master change was seen
+var listenNamespace string         // namespace to listen (watch/get) on
 
 var terminationGracePeriod = time.Minute * 5 // keep calibrated with kubernetes terminationGracePeriodSeconds
 
@@ -104,6 +105,7 @@ func init() {
 	flaggy.Bool(&enableForceMaster, "", "forceMaster", "Set to true to enable local testing, forced master mode.")
 	flaggy.Bool(&enableDebug, "d", "debug", "Set to true to enable debug.")
 	flaggy.String(&logLevel, "", "log-level", fmt.Sprintf("Log level to be used one of [%s].", getAllLogLevel()))
+	flaggy.String(&listenNamespace, "", "listenNamespace", "The namespace kuberhealthy is responsible for.")
 	// Influx flags
 	flaggy.String(&influxUsername, "", "influxUser", "Username for the InfluxDB instance")
 	flaggy.String(&influxPassword, "", "influxPassword", "Password for the InfluxDB instance")
@@ -241,14 +243,14 @@ func initKubernetesClients() error {
 	kubernetesClient = kc
 
 	// make a new crd check client
-	checkClient, err := khcheckcrd.Client(checkCRDGroup, checkCRDVersion, kubeConfigFile, "")
+	checkClient, err := khcheckcrd.Client(checkCRDGroup, checkCRDVersion, kubeConfigFile, listenNamespace)
 	if err != nil {
 		return err
 	}
 	khCheckClient = checkClient
 
 	// make a new crd state client
-	stateClient, err := khstatecrd.Client(stateCRDGroup, stateCRDVersion, kubeConfigFile, "")
+	stateClient, err := khstatecrd.Client(stateCRDGroup, stateCRDVersion, kubeConfigFile, listenNamespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 // status represents the current Kuberhealthy OK:Error state
-var kubeConfigFile = filepath.Join(os.Getenv("KUBECONFIG"))
+var kubeConfigFile = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 var listenAddress = ":8080"
 var podCheckNamespaces = "kube-system"
 var podNamespace = os.Getenv("POD_NAMESPACE")

--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -41,7 +41,7 @@ var podNamespace = os.Getenv("POD_NAMESPACE")
 var isMaster bool                  // indicates this instance is the master and should be running checks
 var upcomingMasterState bool       // the upcoming master state on next interval
 var lastMasterChangeTime time.Time // indicates the last time a master change was seen
-var listenNamespace string         // namespace to listen (watch/get) on
+var listenNamespace string         // namespace to listen (watch/get) `khcheck` resources on.  If blank, all namespaces will be monitored.
 
 var terminationGracePeriod = time.Minute * 5 // keep calibrated with kubernetes terminationGracePeriodSeconds
 
@@ -105,7 +105,7 @@ func init() {
 	flaggy.Bool(&enableForceMaster, "", "forceMaster", "Set to true to enable local testing, forced master mode.")
 	flaggy.Bool(&enableDebug, "d", "debug", "Set to true to enable debug.")
 	flaggy.String(&logLevel, "", "log-level", fmt.Sprintf("Log level to be used one of [%s].", getAllLogLevel()))
-	flaggy.String(&listenNamespace, "", "listenNamespace", "The namespace kuberhealthy is responsible for.")
+	flaggy.String(&listenNamespace, "", "listenNamespace", "Kuberhealthy will only monitor khcheck resources from this namespace, if specified.")
 	// Influx flags
 	flaggy.String(&influxUsername, "", "influxUser", "Username for the InfluxDB instance")
 	flaggy.String(&influxPassword, "", "influxPassword", "Password for the InfluxDB instance")

--- a/cmd/kuberhealthy/reflector.go
+++ b/cmd/kuberhealthy/reflector.go
@@ -23,14 +23,14 @@ type StateReflector struct {
 	store            cache.Store
 }
 
-// NewReflector creates a new StateReflector for watching the state of khstate resoruces on the server
+// NewReflector creates a new StateReflector for watching the state of khstate resources on the server
 func NewStateReflector() *StateReflector {
 	sr := StateReflector{}
 	sr.reflectorSigChan = make(chan struct{})
 	sr.resyncPeriod = time.Minute * 5
 
 	// structure the reflector and its required elements
-	khStateListWatch := cache.NewListWatchFromClient(khStateClient.RestClient(), stateCRDResource, "", fields.Everything())
+	khStateListWatch := cache.NewListWatchFromClient(khStateClient.RestClient(), stateCRDResource, listenNamespace, fields.Everything())
 	sr.store = cache.NewStore(cache.MetaNamespaceKeyFunc)
 	sr.reflector = cache.NewReflector(khStateListWatch, &khstatecrd.KuberhealthyState{}, sr.store, sr.resyncPeriod)
 

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -1073,7 +1073,7 @@ func (ext *Checker) createPod() (*apiv1.Pod, error) {
 	ext.addKuberhealthyLabels(p)
 
 	// Get ownerReference for the kuberhealthy pod
-	ownerRef, err := util.GetOwnerRef(ext.KubeClient, "kuberhealthy")
+	ownerRef, err := util.GetOwnerRef(ext.KubeClient, p.Namespace)
 	if err != nil {
 		return nil, errors.New("Failed to getOwnerReference for pod: " + p.Name + ", err: " + err.Error())
 	}

--- a/pkg/khcheckcrd/api.go
+++ b/pkg/khcheckcrd/api.go
@@ -63,5 +63,5 @@ func Client(GroupName string, GroupVersion string, kubeConfig string, namespace 
 	config.UserAgent = rest.DefaultKubernetesUserAgent()
 
 	client, err := rest.RESTClientFor(&config)
-	return &KuberhealthyCheckClient{restClient: client, ns: namespace}, err
+	return &KuberhealthyCheckClient{restClient: client}, err
 }

--- a/pkg/khcheckcrd/functions.go
+++ b/pkg/khcheckcrd/functions.go
@@ -24,7 +24,6 @@ import (
 // the khstate custom resource
 type KuberhealthyCheckClient struct {
 	restClient rest.Interface
-	ns         string
 }
 
 // Create creates a new resource for this CRD
@@ -37,6 +36,7 @@ func (c *KuberhealthyCheckClient) Create(check *KuberhealthyCheck, resource stri
 		Body(check).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -50,6 +50,7 @@ func (c *KuberhealthyCheckClient) Delete(resource string, name string, namespace
 		Name(name).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -65,6 +66,7 @@ func (c *KuberhealthyCheckClient) Update(check *KuberhealthyCheck, resource stri
 		Name(name).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -79,6 +81,7 @@ func (c *KuberhealthyCheckClient) Get(opts metav1.GetOptions, resource string, n
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -92,19 +95,26 @@ func (c *KuberhealthyCheckClient) List(opts metav1.ListOptions, resource string,
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
 // Watch returns a watch.Interface that watches the requested clusterTestTypes.
-func (c *KuberhealthyCheckClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+//func (c *KuberhealthyCheckClient) Watch(opts metav1.ListOptions, resource, namespace string) (watch.Interface, error) {
+func (c *KuberhealthyCheckClient) Watch(opts metav1.ListOptions, resource string, namespace string) (watch.Interface, error) {
+
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.restClient.Get().
-		Resource("khchecks").
+
+	clientResponse, err := c.restClient.Get().
+		Resource(resource).
+		Namespace(namespace).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch()
+
+	return clientResponse, err
 }

--- a/pkg/khcheckcrd/functions.go
+++ b/pkg/khcheckcrd/functions.go
@@ -104,12 +104,10 @@ func (c *KuberhealthyCheckClient) Watch(opts metav1.ListOptions, resource string
 	}
 	opts.Watch = true
 
-	clientResponse, err := c.restClient.Get().
+	return c.restClient.Get().
 		Resource(resource).
 		Namespace(namespace).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch()
-
-	return clientResponse, err
 }

--- a/pkg/khcheckcrd/functions.go
+++ b/pkg/khcheckcrd/functions.go
@@ -36,7 +36,6 @@ func (c *KuberhealthyCheckClient) Create(check *KuberhealthyCheck, resource stri
 		Body(check).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -50,7 +49,6 @@ func (c *KuberhealthyCheckClient) Delete(resource string, name string, namespace
 		Name(name).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -66,7 +64,6 @@ func (c *KuberhealthyCheckClient) Update(check *KuberhealthyCheck, resource stri
 		Name(name).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -81,7 +78,6 @@ func (c *KuberhealthyCheckClient) Get(opts metav1.GetOptions, resource string, n
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -95,7 +91,6 @@ func (c *KuberhealthyCheckClient) List(opts metav1.ListOptions, resource string,
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 

--- a/pkg/khstatecrd/api.go
+++ b/pkg/khstatecrd/api.go
@@ -59,5 +59,5 @@ func Client(GroupName string, GroupVersion string, kubeConfig string, namespace 
 
 	// log.Println("creating khstate rest client")
 	client, err := rest.RESTClientFor(&config)
-	return &KuberhealthyStateClient{restClient: client, ns: namespace}, err
+	return &KuberhealthyStateClient{restClient: client}, err
 }

--- a/pkg/khstatecrd/functions.go
+++ b/pkg/khstatecrd/functions.go
@@ -24,7 +24,6 @@ import (
 // the khstate custom resource
 type KuberhealthyStateClient struct {
 	restClient rest.Interface
-	ns         string
 }
 
 // ResetClient returns the rest client for easy listWatcher use
@@ -42,6 +41,7 @@ func (c *KuberhealthyStateClient) Create(state *KuberhealthyState, resource stri
 		Body(state).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -55,6 +55,7 @@ func (c *KuberhealthyStateClient) Delete(state *KuberhealthyState, resource stri
 		Name(name).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -70,6 +71,7 @@ func (c *KuberhealthyStateClient) Update(state *KuberhealthyState, resource stri
 		Name(name).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -84,6 +86,7 @@ func (c *KuberhealthyStateClient) Get(opts metav1.GetOptions, resource string, n
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
@@ -97,19 +100,24 @@ func (c *KuberhealthyStateClient) List(opts metav1.ListOptions, resource string,
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
+
 	return &result, err
 }
 
 // Watch returns a watch.Interface that watches the requested clusterTestTypes.
-func (c *KuberhealthyStateClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *KuberhealthyStateClient) Watch(opts metav1.ListOptions, resource string, namespace string) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.restClient.Get().
-		Resource("khstates").
+
+	clientResponse, err := c.restClient.Get().
+		Resource(resource).
+		Namespace(namespace).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch()
+
+	return clientResponse, err
 }

--- a/pkg/khstatecrd/functions.go
+++ b/pkg/khstatecrd/functions.go
@@ -107,12 +107,10 @@ func (c *KuberhealthyStateClient) Watch(opts metav1.ListOptions, resource string
 	}
 	opts.Watch = true
 
-	clientResponse, err := c.restClient.Get().
+	return c.restClient.Get().
 		Resource(resource).
 		Namespace(namespace).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch()
-
-	return clientResponse, err
 }

--- a/pkg/khstatecrd/functions.go
+++ b/pkg/khstatecrd/functions.go
@@ -41,7 +41,6 @@ func (c *KuberhealthyStateClient) Create(state *KuberhealthyState, resource stri
 		Body(state).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -55,7 +54,6 @@ func (c *KuberhealthyStateClient) Delete(state *KuberhealthyState, resource stri
 		Name(name).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -71,7 +69,6 @@ func (c *KuberhealthyStateClient) Update(state *KuberhealthyState, resource stri
 		Name(name).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -86,7 +83,6 @@ func (c *KuberhealthyStateClient) Get(opts metav1.GetOptions, resource string, n
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 
@@ -100,7 +96,6 @@ func (c *KuberhealthyStateClient) List(opts metav1.ListOptions, resource string,
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
 		Into(&result)
-
 	return &result, err
 }
 


### PR DESCRIPTION
in a shared cluster it's not possible to have multiple independent
kuberhealthy deployments (crd, deployment, kuberhealthy checks, ...).

current main reason is, that kuberhealthy controller fetch all
kuberhealthychecks from all namespaces even though all functions
currently accept a *namespace* argument.

within this PR you can opt in kuberhealthy with the command line
argument --listenNamespace and kuberhealthy only act in the defined
namespace. If --listenNamespace isn't defined, behavior is like before
and all khchecks in all namespaces are fetched.

# known issues
- [x] set UUID back seems to be broken --> fixed/solved after rebase on master