### PR TITLE
Update deployment check time limit

### DIFF
--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t jonnydawg/deployment-check:v1.4.2-timeout2 -f Dockerfile ../../
+	docker build -t kuberhealthy/deployment-check:v1.4.3 -f Dockerfile ../../
 
 push:
-	docker push jonnydawg/deployment-check:v1.4.2-timeout2
+	docker push kuberhealthy/deployment-check:v1.4.3

--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/deployment-check:v1.4.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/deployment-check:v1.4.2 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/deployment-check:v1.4.1
+	docker push kuberhealthy/deployment-check:v1.4.2

--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/deployment-check:v1.4.2 -f Dockerfile ../../
+	docker build -t jonnydawg/deployment-check:v1.4.2-timeout2 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/deployment-check:v1.4.2
+	docker push jonnydawg/deployment-check:v1.4.2-timeout2

--- a/cmd/deployment-check/input.go
+++ b/cmd/deployment-check/input.go
@@ -171,19 +171,11 @@ func parseInputValues() {
 	// Set check time limit to default
 	checkTimeLimit = defaultCheckTimeLimit
 	// Get the deadline time in unix from the env var
-	unixDeadline, err := kh.GetDeadline()
+	timeDeadline, err := kh.GetDeadline()
 	if err != nil {
 		log.Infoln("There was an issue getting the check deadline:", err.Error())
 	}
-	// Calculate check run duration from the deadline and now
-	deadline, err := strconv.Atoi(unixDeadline)
-	if err != nil {
-		log.Fatalln("Failed to parse unix deadline from environment.")
-	}
-	if deadline > 0 {
-		log.Infoln("Parsed check deadline time from the environment:", deadline)
-		checkTimeLimit = time.Duration((int64(deadline) - time.Now().Unix() - 5) * 1e9) // Multiply by 1,000,000,000 because that's how many nanoseconds are in a second
-	}
+	checkTimeLimit = timeDeadline.Sub(time.Now().Add(time.Second * 5))
 	log.Infoln("Check time limit set to:", checkTimeLimit)
 
 	// Parse incoming deployment rolling-update environment variable

--- a/cmd/deployment-check/input.go
+++ b/cmd/deployment-check/input.go
@@ -182,8 +182,9 @@ func parseInputValues() {
 	}
 	if deadline > 0 {
 		log.Infoln("Parsed check deadline time from the environment:", deadline)
-		checkTimeLimit = time.Duration((int64(deadline) - time.Now().Unix()) * 1e9) // Multiply by 1,000,000,000 because that's how many nanoseconds are in a second
+		checkTimeLimit = time.Duration((int64(deadline) - time.Now().Unix() - 5) * 1e9) // Multiply by 1,000,000,000 because that's how many nanoseconds are in a second
 	}
+	log.Infoln("Check time limit set to:", checkTimeLimit)
 
 	// Parse incoming deployment rolling-update environment variable
 	if len(rollingUpdateEnv) != 0 {

--- a/cmd/test-external-check/Makefile
+++ b/cmd/test-external-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/test-external-check:v1.3.0 -f Dockerfile ../../
+	docker build -t kuberhealthy/test-external-check:v1.3.1 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/test-external-check:v1.3.0
+	docker push kuberhealthy/test-external-check:v1.3.1

--- a/cmd/test-external-check/main.go
+++ b/cmd/test-external-check/main.go
@@ -46,19 +46,12 @@ func init() {
 	// Set check time limit to default
 	timeLimit = time.Duration(time.Minute * 10)
 	// Get the deadline time in unix from the env var
-	unixDeadline, err := checkclient.GetDeadline()
+	timeDeadline, err := checkclient.GetDeadline()
 	if err != nil {
 		log.Println("There was an issue getting the check deadline:", err.Error())
 	}
-	// Calculate check run duration from the deadline and now
-	deadline, err := strconv.Atoi(unixDeadline)
-	if err != nil {
-		log.Fatalln("Failed to parse unix deadline from environment.")
-	}
-	if deadline > 0 {
-		log.Println("Parsed check deadline time from the environment:", deadline)
-		timeLimit = time.Duration((int64(deadline) - time.Now().Unix()) * 1e9) // Multiply by 1,000,000,000 because that's how many nanoseconds are in a second
-	}
+	timeLimit = timeDeadline.Sub(time.Now().Add(time.Second * 5))
+	log.Println("Check time limit set to:", timeLimit)
 }
 
 func main() {


### PR DESCRIPTION
subtract 5s from time-limit;bump version

Subtracts 5s from the time limit to ensure that the check reports its last stage before timing out.
Bumps the version up a patch number.