### PR TITLE
make the default namespace for deployment check the same as the pod's

### DIFF
--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/deployment-check:v1.4.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/deployment-check:v1.4.3 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/deployment-check:v1.4.1
+	docker push kuberhealthy/deployment-check:v1.4.3

--- a/cmd/deployment-check/input.go
+++ b/cmd/deployment-check/input.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -96,6 +97,14 @@ func parseInputValues() {
 
 	// Parse incoming namespace environment variable
 	checkNamespace = defaultCheckNamespace
+	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		log.Warnln("Failed to open namespace file:", err.Error())
+	}
+	if len(data) != 0 {
+		log.Infoln("Found pod namespace:", string(data))
+		checkNamespace = string(data)
+	}
 	if len(checkNamespaceEnv) != 0 {
 		checkNamespace = checkNamespaceEnv
 		log.Infoln("Parsed CHECK_NAMESPACE:", checkNamespace)


### PR DESCRIPTION
Addresses #467 by making the default check namespace the same as the pod's (the deployment should now default to doing its check in the `khcheck`'s namespace)