### PR TITLE
added info about errors in Prometheus' metrics

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -44,7 +44,13 @@ func GenerateMetrics(state health.State) string {
 		if d.OK {
 			checkStatus = "1"
 		}
-		metricName := fmt.Sprintf("kuberhealthy_check{check=\"%s\",namespace=\"%s\",status=\"%s\"}", c, d.Namespace, checkStatus)
+		errors := ""
+		if len(d.Errors) > 0 {
+			for _, error := range d.Errors {
+				errors += fmt.Sprintf("%s|", error)
+			}
+		}
+		metricName := fmt.Sprintf("kuberhealthy_check{check=\"%s\",namespace=\"%s\",status=\"%s\",error=\"%s\"}", c, d.Namespace, checkStatus, errors)
 		metricDurationName := fmt.Sprintf("kuberhealthy_check_duration_seconds{check=\"%s\",namespace=\"%s\"}", c, d.Namespace)
 		checkMetricState[metricName] = checkStatus
 		runDuration, err := time.ParseDuration(d.RunDuration)


### PR DESCRIPTION
I'm using Prometheus and Alertmanager to send Kuberhealthy errors to a Slack channel.

With this PR I have included the errors which are causing the check failure, so they can be included in any notifications from Alertmanager.

The format of string representing errors is `error1|error2`