### PR TITLE
Edit notifychanlimiter, revert k8s pods not found case

### DIFF
--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -616,7 +617,7 @@ func waitForDeploymentToDelete() chan bool {
 			_, err := client.AppsV1().Deployments(checkNamespace).Get(checkDeploymentName, metav1.GetOptions{})
 			if err != nil {
 				log.Debugln("error from Deployments().Get():", err.Error())
-				if k8sErrors.IsNotFound(err) {
+				if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
 					log.Debugln("Deployment deleted.")
 					deleteChan <- true
 					return

--- a/cmd/deployment-check/service.go
+++ b/cmd/deployment-check/service.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/ fpkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	watchpkg "k8s.io/apimachinery/pkg/watch"
 )
 

--- a/cmd/deployment-check/service.go
+++ b/cmd/deployment-check/service.go
@@ -393,7 +393,7 @@ func waitForServiceToDelete() chan bool {
 			_, err := client.CoreV1().Services(checkNamespace).Get(checkServiceName, metav1.GetOptions{})
 			if err != nil {
 				log.Debugln("error from Services().Get():", err.Error())
-				if k8sErrors.IsNotFound(err) {
+				if (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
 					log.Debugln("Service deleted.")
 					deleteChan <- true
 					return

--- a/cmd/deployment-check/service.go
+++ b/cmd/deployment-check/service.go
@@ -17,12 +17,13 @@ import (
 	"fmt"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/ fpkg/util/intstr"
 	watchpkg "k8s.io/apimachinery/pkg/watch"
 )
 
@@ -393,7 +394,7 @@ func waitForServiceToDelete() chan bool {
 			_, err := client.CoreV1().Services(checkNamespace).Get(checkServiceName, metav1.GetOptions{})
 			if err != nil {
 				log.Debugln("error from Services().Get():", err.Error())
-				if (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
+				if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
 					log.Debugln("Service deleted.")
 					deleteChan <- true
 					return

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -2,10 +2,10 @@
 # TAG="2.2.0"
 
 build:
-	docker build -t kuberhealthy/kuberhealthy:v2.2.0 -f Dockerfile ../../
+	docker build -t kuberhealthy/kuberhealthy:v2.2.1 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/kuberhealthy:v2.2.0
+	docker push kuberhealthy/kuberhealthy:v2.2.1
 
 test:
 	POD_NAME="kuberhealthy-test" go test -run TestWebServer -v -args -- --debug --forceMaster

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -2,10 +2,10 @@
 # TAG="2.2.0"
 
 build:
-	docker build -t kuberhealthy/kuberhealthy:v2.2.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/kuberhealthy:v2.2.1-test -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/kuberhealthy:v2.2.1
+	docker push kuberhealthy/kuberhealthy:v2.2.1-test
 
 test:
 	POD_NAME="kuberhealthy-test" go test -run TestWebServer -v -args -- --debug --forceMaster

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -2,10 +2,10 @@
 # TAG="2.2.0"
 
 build:
-	docker build -t kuberhealthy/kuberhealthy:v2.2.1-test -f Dockerfile ../../
+	docker build -t kuberhealthy/kuberhealthy:v2.2.1 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/kuberhealthy:v2.2.1-test
+	docker push kuberhealthy/kuberhealthy:v2.2.1
 
 test:
 	POD_NAME="kuberhealthy-test" go test -run TestWebServer -v -args -- --debug --forceMaster

--- a/cmd/kuberhealthy/crd.go
+++ b/cmd/kuberhealthy/crd.go
@@ -70,7 +70,7 @@ func ensureStateResourceExists(checkName string, checkNamespace string) error {
 	log.Debugln("Checking existence of custom resource:", name)
 	state, err := khStateClient.Get(metav1.GetOptions{}, stateCRDResource, name, checkNamespace)
 	if err != nil {
-		if k8sErrors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
 			log.Infoln("Custom resource not found, creating resource:", name, " - ", err)
 			initialDetails := health.NewCheckDetails()
 			initialState := khstatecrd.NewKuberhealthyState(name, initialDetails)

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -54,10 +54,11 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 			select {
 			case <-time.After(maxSpeed):
 				outChan <- struct{}{}
-				return
+				break
 			case <-inChan:
 				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
 			}
+			return
 		}
 	}
 }

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -49,17 +49,23 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 	// we wait for an initial inChan message and then watch for spam to stop.
 	// when inChan closes, the func exits
 	for range inChan {
-		log.Println("channel notify limiter witnessed an upstream message on inChan")
+		log.Infoln("channel notify limiter witnessed an upstream message on inChan")
+
+		notifyChannel:
 		for {
+			log.Debugln("channel notify limiter waiting to receive another inChan or notify after 10s.")
 			select {
 			case <-time.After(maxSpeed):
+				log.Infoln("channel notify limiter reached", maxSpeed, ". Sending output")
 				outChan <- struct{}{}
-				break
+				break notifyChannel
 			case <-inChan:
-				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
+				log.Infoln("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
 			}
 			return
 		}
+
+		log.Infoln("channel notify limiter finished for now. Waiting for next inChan.")
 	}
 }
 

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -54,7 +54,7 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 			select {
 			case <-time.After(maxSpeed):
 				outChan <- struct{}{}
-				break
+				return
 			case <-inChan:
 				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
 			}

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -52,12 +52,11 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 		log.Println("channel notify limiter witnessed an upstream message on inChan")
 		for {
 			select {
-			//case <-time.After(maxSpeed):
-			//	outChan <- struct{}{}
+			case <-time.After(maxSpeed):
+				outChan <- struct{}{}
+				break
 			case <-inChan:
 				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
-				time.After(maxSpeed)
-				outChan <- struct{}{}
 			}
 		}
 	}

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -53,7 +53,7 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 
 		notifyChannel:
 		for {
-			log.Debugln("channel notify limiter waiting to receive another inChan or notify after 10s.")
+			log.Debugln("channel notify limiter waiting to receive another inChan or notify after", maxSpeed)
 			select {
 			case <-time.After(maxSpeed):
 				log.Infoln("channel notify limiter reached", maxSpeed, ". Sending output")
@@ -62,7 +62,6 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 			case <-inChan:
 				log.Infoln("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
 			}
-			return
 		}
 
 		log.Infoln("channel notify limiter finished for now. Waiting for next inChan.")

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -51,20 +51,22 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 	for range inChan {
 		log.Infoln("channel notify limiter witnessed an upstream message on inChan")
 
+		// Label for following for-select loop
 		notifyChannel:
-		for {
-			log.Debugln("channel notify limiter waiting to receive another inChan or notify after", maxSpeed)
-			select {
-			case <-time.After(maxSpeed):
-				log.Infoln("channel notify limiter reached", maxSpeed, ". Sending output")
-				outChan <- struct{}{}
-				break notifyChannel
-			case <-inChan:
-				log.Infoln("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
+			for {
+				log.Debugln("channel notify limiter waiting to receive another inChan or notify after", maxSpeed)
+				select {
+				case <-time.After(maxSpeed):
+					log.Debugln("channel notify limiter reached", maxSpeed, ". Sending output")
+					outChan <- struct{}{}
+					// break out of the for-select loop and go through next inChan loop iteration if any.
+					break notifyChannel
+				case <-inChan:
+					log.Debugln("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
+				}
 			}
-		}
 
-		log.Infoln("channel notify limiter finished for now. Waiting for next inChan.")
+		log.Debugln("channel notify limiter finished going through notifications")
 	}
 }
 

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -40,7 +40,7 @@ func getAllLogLevel() string {
 }
 
 // notifyChanLimiter takes in a chan used for notifications and smooths it out to at most
-// one single notification every specifid duration.  This will continuously empty whatever the inChan
+// one single notification every specified duration.  This will continuously empty whatever the inChan
 // channel fed to it is.  Useful for controlling noisy upstream channel spam. This smooths notifications
 // out so that outChan is only notified after inChan has been quiet for a full duration of
 // the specified maxSpeed.  Stops running when inChan closes
@@ -52,10 +52,12 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 		log.Println("channel notify limiter witnessed an upstream message on inChan")
 		for {
 			select {
-			case <-time.After(maxSpeed):
-				outChan <- struct{}{}
+			//case <-time.After(maxSpeed):
+			//	outChan <- struct{}{}
 			case <-inChan:
 				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
+				time.After(maxSpeed)
+				outChan <- struct{}{}
 			}
 		}
 	}

--- a/cmd/pod-restarts-check/main.go
+++ b/cmd/pod-restarts-check/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -191,7 +192,7 @@ func (prc *Checker) verifyBadPodRestartExists(podName string) error {
 
 	_, err := prc.client.CoreV1().Pods(prc.Namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
-		if k8sErrors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
 			log.Infoln("Bad Pod:", podName, "no longer exists. Removing from bad pods map")
 			delete(prc.BadPods, podName)
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.3.0
 
 require (
 	cloud.google.com/go v0.38.0 // indirect
-	github.com/Azure/go-autorest/autorest v0.9.0 // indirect
 	github.com/Pallinder/go-randomdata v1.1.0
 	github.com/aws/aws-sdk-go v1.25.24
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,13 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
-github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
-github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
-github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
-github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
-github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
-github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
-github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Pallinder/go-randomdata v1.1.0 h1:gUubB1IEUliFmzjqjhf+bgkg1o6uoFIkRsP3VrhEcx8=
 github.com/Pallinder/go-randomdata v1.1.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
@@ -24,7 +17,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denverdino/aliyungo v0.0.0-20191023002520-dba750c0c223 h1:elQ0hc59adZkbmMJcs1uZIahEGzoxHxr+8/Xt1oM55U=
 github.com/denverdino/aliyungo v0.0.0-20191023002520-dba750c0c223/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -170,7 +170,7 @@ func (ext *Checker) CurrentStatus() (bool, []string) {
 	// fetch the state from the resource
 	state, err := ext.getKHState()
 	if err != nil {
-		if k8sErrors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
 			// if the resource is not found, we default to "up" so not to throw alarms before the first run completes
 			return true, []string{}
 		}
@@ -283,17 +283,13 @@ func (ext *Checker) cleanup() {
 	wg.Wait()
 }
 
-// evictPod evicts a pod in a namespace and ignores errors. Uses a static 30s grace period
+// evictPod evicts a pod in a namespace and ignores errors.
 func (ext *Checker) evictPod(podName string, podNamespace string) {
 	podClient := ext.KubeClient.CoreV1().Pods(podNamespace)
-	gracePeriodSeconds := int64(30)
 	eviction := &policyv1.Eviction{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: podNamespace,
-		},
-		DeleteOptions: &metav1.DeleteOptions{
-			GracePeriodSeconds: &gracePeriodSeconds,
 		},
 	}
 	err := podClient.Evict(eviction)
@@ -308,12 +304,12 @@ func (ext *Checker) setUUID(uuid string) error {
 	checkState, err := ext.getKHState()
 
 	// if the fetch operation had an error, but it wasn't 'not found', we return here
-	if err != nil && !k8sErrors.IsNotFound(err) {
+	if err != nil && !(k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
 		return fmt.Errorf("error setting uuid for check %s %w", ext.CheckName, err)
 	}
 
 	// if the check was not found, we create a fresh one and start there
-	if err != nil && k8sErrors.IsNotFound(err) {
+	if err != nil && (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
 		ext.log("khstate did not exist, so a default object will be created")
 		details := health.NewCheckDetails()
 		details.Namespace = ext.CheckNamespace()
@@ -717,7 +713,7 @@ func (ext *Checker) deletePod(podName string) error {
 		GracePeriodSeconds: &gracePeriodSeconds,
 		PropagationPolicy:  &deletionPolicy,
 	})
-	if err != nil && !k8sErrors.IsNotFound(err) {
+	if err != nil && !(k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
 		return err
 	}
 	return nil
@@ -752,7 +748,7 @@ func (ext *Checker) getCheckLastUpdateTime() (time.Time, error) {
 
 	// fetch the state from the resource
 	state, err := ext.getKHState()
-	if err != nil && k8sErrors.IsNotFound(err) {
+	if err != nil && (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
 		return time.Time{}, nil
 	}
 
@@ -861,7 +857,7 @@ func (ext *Checker) waitForAllPodsToClear() chan error {
 
 			// if we got a "not found" message, then we are done.  This is the happy path.
 			if err != nil {
-				if k8sErrors.IsNotFound(err) {
+				if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
 					ext.log("all pods cleared")
 					outChan <- nil
 					return
@@ -1199,7 +1195,8 @@ func (ext *Checker) podExists() (bool, error) {
 
 	// if the pod is "not found", then it does not exist
 	p, err := podClient.Get(ext.podName(), metav1.GetOptions{})
-	if err != nil && strings.Contains(err.Error(), "not found") {
+	// Check both k8sErrors and Error string message for not found
+	if err != nil && (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
 		return false, nil
 	}
 

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -1199,7 +1199,7 @@ func (ext *Checker) podExists() (bool, error) {
 
 	// if the pod is "not found", then it does not exist
 	p, err := podClient.Get(ext.podName(), metav1.GetOptions{})
-	if err != nil && k8sErrors.IsNotFound(err) {
+	if err != nil && strings.Contains(err.Error(), "not found") {
 		return false, nil
 	}
 


### PR DESCRIPTION
2 Bugs:

1) Notifychanlimiter:
- constantly signaled a change every 10secs to the `externalChecksUpdateChanLimited` channel causing khchecks to restart and reload configurations every 10 secs -- this blocked kuberhealthy from actually running
2) Not sure if `k8sErrors.IsNotFound(err)` actually fits this situation as I observed kuberhealthy get stuck in a loop with:
```
time="2020-05-22T22:15:05Z" level=info msg=" kuberhealthy/deployment: [pod  in  exists]"
time="2020-05-22T22:15:05Z" level=info msg=" kuberhealthy/daemonset: [pod  in  exists]"
time="2020-05-22T22:15:10Z" level=info msg=" kuberhealthy/deployment: [pod  in  exists]"
time="2020-05-22T22:15:10Z" level=info msg=" kuberhealthy/daemonset: [pod  in  exists]"
time="2020-05-22T22:15:15Z" level=info msg=" kuberhealthy/daemonset: [pod  in  exists]"
time="2020-05-22T22:15:15Z" level=info msg=" kuberhealthy/deployment: [pod  in  exists]"
time="2020-05-22T22:15:20Z" level=info msg=" kuberhealthy/daemonset: [pod  in  exists]"
time="2020-05-22T22:15:20Z" level=info msg=" kuberhealthy/deployment: [pod  in  exists]"
time="2020-05-22T22:15:25Z" level=info msg=" kuberhealthy/daemonset: [pod  in  exists]"
```
^ Pod did not exist, yet the `if k8sErrors.IsNotFound(err)` condition didn't catch that