### PR TITLE
Image pull checker and eviction fix

### DIFF
--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -40,7 +40,7 @@ func getAllLogLevel() string {
 }
 
 // notifyChanLimiter takes in a chan used for notifications and smooths it out to at most
-// one single notification every specifid duration.  This will continuously empty whatever the inChan
+// one single notification every specified duration.  This will continuously empty whatever the inChan
 // channel fed to it is.  Useful for controlling noisy upstream channel spam. This smooths notifications
 // out so that outChan is only notified after inChan has been quiet for a full duration of
 // the specified maxSpeed.  Stops running when inChan closes
@@ -49,17 +49,24 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 	// we wait for an initial inChan message and then watch for spam to stop.
 	// when inChan closes, the func exits
 	for range inChan {
-		log.Println("channel notify limiter witnessed an upstream message on inChan")
+		log.Infoln("channel notify limiter witnessed an upstream message on inChan")
+
+		// Label for following for-select loop
+	notifyChannel:
 		for {
+			log.Debugln("channel notify limiter waiting to receive another inChan or notify after", maxSpeed)
 			select {
 			case <-time.After(maxSpeed):
+				log.Debugln("channel notify limiter reached", maxSpeed, ". Sending output")
 				outChan <- struct{}{}
-				break
+				// break out of the for-select loop and go through next inChan loop iteration if any.
+				break notifyChannel
 			case <-inChan:
-				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
+				log.Debugln("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
 			}
-			return
 		}
+
+		log.Debugln("channel notify limiter finished going through notifications")
 	}
 }
 

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -54,9 +54,11 @@ func notifyChanLimiter(maxSpeed time.Duration, inChan chan struct{}, outChan cha
 			select {
 			case <-time.After(maxSpeed):
 				outChan <- struct{}{}
+				break
 			case <-inChan:
 				log.Println("channel notify limiter witnessed an upstream message on inChan and is waiting an additional", maxSpeed, "before sending output")
 			}
+			return
 		}
 	}
 }

--- a/cmd/test-external-check/README.md
+++ b/cmd/test-external-check/README.md
@@ -48,13 +48,14 @@ spec:
 
 ### image-pull-check
 
-This is a container used to test availability of external image respositories in Kuberhealthy.  Simply place the `kuberhealthy/test-external-check` image on the repository you need tested.
-
-##### Example `khcheck`
+This container tests the availability of external image respositories using Kuberhealthy.  Simply place the `kuberhealthy/test-external-check` image on the repository you need tested.
 
 The pod is designed to attempt a pull of the test image from the remote repository (never from local) every 10 minutes. If the image is unavailable, an error will be reported to the Kuberheakthy API.
 
 To put a copy of this image to your repository, run `docker pull kuberhealthy/test-external-check` and then `docker push my.repository/repo/test-external-check`.
+
+
+##### Example `khcheck`
 
 Below is a YAML template for enabling the image-pull-check in Kuberhealthy.
 

--- a/cmd/test-external-check/README.md
+++ b/cmd/test-external-check/README.md
@@ -45,3 +45,46 @@ spec:
           cpu: 10m
           memory: 50Mi
 ```
+
+### image-pull-check
+
+This is a container used to test availability of external image respositories in Kuberhealthy.  Simply place the `kuberhealthy/test-external-check` image on the repository you need tested.
+
+##### Example `khcheck`
+
+The pod is designed to attempt a pull of the test image from the remote repository (never from local) every 10 minutes. If the image is unavailable, an error will be reported to the Kuberheakthy API.
+
+To put a copy of this image to your repository, run `docker pull kuberhealthy/test-external-check` and then `docker push my.repository/repo/test-external-check`.
+
+Below is a YAML template for enabling the image-pull-check in Kuberhealthy.
+
+Simply copy and paste the YAML specs below into a new file and apply it by using the command `kubectl apply -f your-named-khcheck.yaml`.
+
+```yaml
+---
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: image-pull-check
+  namespace: default
+spec:
+  podSpec:
+    containers:
+    - env:
+      - name: REPORT_FAILURE
+        value: "false"
+      - name: REPORT_DELAY
+        value: "1s"
+      # test-external-check image must be uploaded to the repository you wish to test on, and below URL must be updated to match.
+      image: kuberhealthy/test-external-check:v1.2.1
+      imagePullPolicy: Always
+      name: main
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+  runInterval: 10m
+  timeout: 1m
+```
+
+You can change the default specs as needed in the above YAML to extend or shorten timeouts, run intervals, etc.

--- a/cmd/test-external-check/image-pull-check.yaml
+++ b/cmd/test-external-check/image-pull-check.yaml
@@ -13,7 +13,7 @@ spec:
       - name: REPORT_DELAY
         value: "1s"
       # test-external-check image must be uploaded to the repository you wish to test on, and below URL must be updated to match.
-      image: kuberhealthy/test-external-check:v1.1.0
+      image: kuberhealthy/test-external-check:v1.3.1
       imagePullPolicy: Always
       name: main
       resources:

--- a/cmd/test-external-check/image-pull-check.yaml
+++ b/cmd/test-external-check/image-pull-check.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: image-pull-check
+  namespace: kuberhealthy
+spec:
+  podSpec:
+    containers:
+    - env:
+      - name: REPORT_FAILURE
+        value: "false"
+      - name: REPORT_DELAY
+        value: "1s"
+      # test-external-check image must be uploaded to the repository you wish to test on, and below URL must be updated to match.
+      image: kuberhealthy/test-external-check:v1.1.0
+      imagePullPolicy: Always
+      name: main
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+  runInterval: 10m
+  timeout: 1m

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -253,7 +253,7 @@ func (ext *Checker) getCheck() (*khcheckcrd.KuberhealthyCheck, error) {
 	return checkConfig, err
 }
 
-// cleanup cleans up any running, pending, or unknown checker pods by evicting them. Succeeded of Failed pods are left alone for records
+// cleanup cleans up any running, pending, or unknown checker pods by evicting them. Succeeded or Failed pods are left alone for records
 // if eviction fails, cleanup will attempt to forcefully kill the pod.
 func (ext *Checker) cleanup() {
 	ext.log("Evicting up any running pods with name", ext.podName())

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -279,16 +279,11 @@ func (ext *Checker) cleanup() {
 		if p.Status.Phase != apiv1.PodFailed || p.Status.Phase != apiv1.PodSucceeded {
 			wg.Add(1)
 			go func(p apiv1.Pod) {
-				ext.log("evicting pod", p.GetName())
+				ext.log("evicting pod", p.GetName(), "from namespace", p.GetNamespace())
 				err := ext.evictPod(p.GetName(), p.GetNamespace())
 				if err != nil {
-					ext.log("pod eviction failed"+":", err)
-					ext.log("checking if pod", p.GetName, "still exists")
-					podExists, podErr := util.PodNameExists(ext.KubeClient, p.GetName(), p.GetNamespace())
-					if !podExists {
-						ext.log("Pod does not exist"+":", podErr)
-					} else {
-						ext.log("forcefull killing pod", p.GetName, "in 15 seconds")
+					podExists, _ := util.PodNameExists(ext.KubeClient, p.GetName(), p.GetNamespace())
+					if podExists == true {
 						err := util.PodKill(ext.KubeClient, p.GetName(), p.GetNamespace(), 15)
 						if err != nil {
 							ext.log("error killing pod", p.GetName()+":", err)

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -279,12 +279,12 @@ func (ext *Checker) cleanup() {
 		if p.Status.Phase != apiv1.PodFailed || p.Status.Phase != apiv1.PodSucceeded {
 			wg.Add(1)
 			go func(p apiv1.Pod) {
+				defer wg.Done()
 				ext.log("evicting pod", p.GetName(), "from namespace", p.GetNamespace())
 				err := ext.evictPod(p.GetName(), p.GetNamespace())
 				if err != nil {
 					ext.log("error killing pod", p.GetName()+":", err)
 				}
-				wg.Done()
 			}(p)
 		}
 	}

--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -289,7 +289,10 @@ func (ext *Checker) cleanup() {
 						ext.log("Pod does not exist"+":", podErr)
 					} else {
 						ext.log("forcefull killing pod", p.GetName, "in 15 seconds")
-						util.PodKill(ext.KubeClient, p.GetName(), p.GetNamespace(), 15)
+						err := util.PodKill(ext.KubeClient, p.GetName(), p.GetNamespace(), 15)
+						if err != nil {
+							ext.log("error killing pod", p.GetName()+":", err)
+						}
 					}
 				}
 				wg.Done()

--- a/pkg/checks/external/util/main.go
+++ b/pkg/checks/external/util/main.go
@@ -7,10 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -88,4 +89,48 @@ func GetInstanceNamespace(defaultNamespace string) string {
 	}
 
 	return instanceNamespace
+}
+
+// PodNameExists determines if a pod with the specified name exists in the specified namespace.
+func PodNameExists(client *kubernetes.Clientset, podName string, namespace string) (bool, error) {
+
+	// setup a pod watching client for our current KH pod
+	podClient := client.CoreV1().Pods(namespace)
+
+	// if the pod is "not found", then it does not exist
+	p, err := podClient.Get(podName, metav1.GetOptions{})
+	if err != nil && (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
+		log.Warnln("Pod", podName, "in namespace", namespace, "was not found"+":", err.Error)
+		return false, err
+	}
+
+	// if the pod has succeeded, it no longer exists
+	if p.Status.Phase == apiv1.PodSucceeded {
+		log.Infoln("Pod", podName, "exited successfully.")
+		return false, err
+	}
+
+	// if the pod has failed, it no longer exists
+	if p.Status.Phase == apiv1.PodFailed {
+		log.Infoln("Pod", podName, "failed and no longer exists.")
+		return false, err
+	}
+	log.Infoln("Pod", podName, "is present in namespace", namespace)
+	return true, nil
+}
+
+// PodKill waits a number of seconds determined by the user, then deletes the chosen pod in the namespace specified
+func PodKill(client *kubernetes.Clientset, podName string, namespace string, gracePeriod int64) error {
+
+	// Setup a pod watching client for our current KH pod
+	podClient := client.CoreV1().Pods(namespace)
+
+	// Check for and return any errors, otherwise pod was killed successfully
+	err := podClient.Delete(podName, &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+	if err != nil && (k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
+		log.Warnln("Pod", podName, "not found not found in namespace", namespace+":", err.Error)
+		return err
+	}
+	log.Infoln("Pod", podName, "was killed successfully.")
+	return nil
 }


### PR DESCRIPTION
This commit resolves issues [#221](https://github.com/Comcast/kuberhealthy/issues/221) and [#473](https://github.com/Comcast/kuberhealthy/issues/473) with the following updates:

- Adds an external image pull check to test-external-check
- Adds more in depth PodKill and PodNameExists functions to util package
- Updates cleanup function:
    -Adds error return to evictPod function
    -Checks for pods that are not in Failed or Succeeded state, instead of only Running state.
    -If evictPod returns an error, run util.PodNameExists and if it returns true, run util.PodKill, 
      returning any errors