### PR TITLE
disable two checks for gosec

### DIFF
--- a/.github/workflows/gosec-latest-checks.yaml
+++ b/.github/workflows/gosec-latest-checks.yaml
@@ -19,4 +19,6 @@ jobs:
       - name: Run Gosec Security Scanner 
         #G107: Url provided to HTTP request as taint input
         #G109: Potential Integer overflow made by strconv.Atoi result conversion to int16/32
-        run: gosec -exclude=G107,G109 ./...
+        #G304: prevent loading configuration files from variable locations (we want to do this in local development)
+        #G601: Implicit memory aliasing in for loop.  (disabled due to false positives for safe code)
+        run: gosec -exclude=G107,G109,G304,G601 ./...


### PR DESCRIPTION
Disables two checks for `gosec`:

        #G304: prevent loading configuration files from variable locations (we want to do this in local development)
        #G601: Implicit memory aliasing in for loop.  (disabled due to false positives for safe code)