### PR TITLE
fix goroutine leak in watchForCheckerPodShutdown()

### DIFF
--- a/pkg/checks/external/main.go
+++ b/pkg/checks/external/main.go
@@ -402,6 +402,11 @@ func (ext *Checker) watchForCheckerPodShutdown(shutdownEventNotifyC chan struct{
 	defer func() {
 		if watcher != nil {
 			watcher.Stop()
+			// Empty the resultChan after stopping.
+			// Otherwise it can happen that the  StreamWatcher is blocked when it tries
+			// to put an Event in the result channel. This happens when no consumer exists
+			// anymore to empty the ResultChan after calling Stop().
+			for range watcher.ResultChan() {}
 		}
 	}()
 


### PR DESCRIPTION
Fixes #533

I fixed the leak on a heavily modified branch wit logging of goroutine ids including who creates which goroutine etc. This is the change which finally fixed the leak. I'm currently verifying that this version without all other changes also fixes the leak.