### PR TITLE
Address bug 447. Modify eviction for pods not in failed / succeeded phase.

### DIFF
--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -2,10 +2,10 @@
 # TAG="2.2.0"
 
 build:
-	docker build -t kuberhealthy:v2.2.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/kuberhealthy:v2.2.2 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/kuberhealthy:v2.2.1
+	docker push kuberhealthy/kuberhealthy:v2.2.2
 
 test:
 	POD_NAME="kuberhealthy-test" go test -run TestWebServer -v -args -- --debug --forceMaster


### PR DESCRIPTION
Addresses #447.

When a khcheck pod is stuck in pending or "container creating" this blocks the main kuberhealthy process. The eviction policy modification added in pr #516 addresses the state when khcheck pods are stuck in imagepullerror status, but does not cover "pending" status. Added a select and timeout during the waitForShutdown process in the external main.go package so that the main kuberhealthy process doesn't get stuck until the check timeout or next run iteration. 

Also, modified eviction filtering for running, pending, or unknown pods instead of excluding succeeded or failed pods. Seems like ` p.Status.Phase != apiv1.PodFailed || p.Status.Phase != apiv1.PodSucceeded` wasn't working as expected and all of that khchecker pods were getting evicted instead of evicting just the nonfailed/succeeded pods.