### PR TITLE
Set timeout for context cancel with timeout greater than check time l…

### DIFF
--- a/cmd/daemonset-check/cleanup.go
+++ b/cmd/daemonset-check/cleanup.go
@@ -12,7 +12,7 @@ import (
 // cleanUp triggers check clean up and waits for all rogue daemonsets to clear
 func cleanUp(ctx context.Context) error {
 
-	log.Debugln("Allowing clean up", checkTimeLimit, "to finish.")
+	log.Debugln("Allowing clean up", shutdownGracePeriod, "to finish.")
 
 	// Clean up daemonsets and daemonset pods
 	// deleteDS not only issues a delete on the rogue daemonset but also on the rogue daemonset pods

--- a/cmd/daemonset-check/input.go
+++ b/cmd/daemonset-check/input.go
@@ -17,6 +17,9 @@ func parseInputValues() {
 	if err != nil {
 		log.Infoln("There was an issue getting the check deadline:", err.Error())
 	}
+	checkTimeout = timeDeadline.Sub(time.Now().Add(time.Second * 5))
+	log.Infoln("Check time out set to:", checkTimeout)
+
 	// Give 60 seconds to clean up / shut down once check time limit is reached before the kh deadline
 	checkTimeLimit = timeDeadline.Sub(time.Now().Add(time.Second * 60))
 	log.Infoln("Setting check time limit to:", checkTimeLimit)

--- a/cmd/daemonset-check/input.go
+++ b/cmd/daemonset-check/input.go
@@ -11,18 +11,32 @@ import (
 // parseInputValues parses and sets global vars from env variables and other inputs
 func parseInputValues() {
 
-	// Use injected pod variable KH_CHECK_RUN_DEADLINE to set check time limit
-	checkTimeLimit = defaultCheckTimeLimit
-	timeDeadline, err := kh.GetDeadline()
+	// Parse incoming custom shutdown grace period seconds
+	shutdownGracePeriod = defaultShutdownGracePeriod
+	if len(shutdownGracePeriodEnv) != 0 {
+		duration, err := time.ParseDuration(shutdownGracePeriodEnv)
+		if err != nil {
+			log.Fatalln("error occurred attempting to parse SHUTDOWN_GRACE_PERIOD:", err)
+		}
+		if duration.Minutes() < 1 {
+			log.Fatalln("error occurred attempting to parse SHUTDOWN_GRACE_PERIOD. A value less than 1 was parsed:", duration.Minutes())
+		}
+		shutdownGracePeriod = duration
+		log.Infoln("Parsed SHUTDOWN_GRACE_PERIOD:", shutdownGracePeriod)
+	}
+	log.Infoln("Setting shutdown grace period to:", shutdownGracePeriod)
+
+	// Use injected pod variable KH_CHECK_RUN_DEADLINE to set check timeout
+	checkDeadline = now.Add(defaultCheckDeadline)
+	var err error
+	khDeadline, err = kh.GetDeadline()
 	if err != nil {
 		log.Infoln("There was an issue getting the check deadline:", err.Error())
 	}
-	checkTimeout = timeDeadline.Sub(time.Now().Add(time.Second * 5))
-	log.Infoln("Check time out set to:", checkTimeout)
 
-	// Give 60 seconds to clean up / shut down once check time limit is reached before the kh deadline
-	checkTimeLimit = timeDeadline.Sub(time.Now().Add(time.Second * 60))
-	log.Infoln("Setting check time limit to:", checkTimeLimit)
+	// Give check just until the shutdownGracePeriod to finish before it hits the kh deadline
+	checkDeadline = khDeadline.Add(-shutdownGracePeriod)
+	log.Infoln("Check deadline in", checkDeadline.Sub(now))
 
 	// Parse incoming namespace environment variable
 	checkNamespace = defaultCheckNamespace
@@ -40,20 +54,6 @@ func parseInputValues() {
 	}
 	log.Infoln("Setting DS pause container image to:", dsPauseContainerImage)
 
-	// Parse incoming custom shutdown grace period seconds
-	shutdownGracePeriod = defaultShutdownGracePeriod
-	if len(shutdownGracePeriodEnv) != 0 {
-		duration, err := time.ParseDuration(shutdownGracePeriodEnv)
-		if err != nil {
-			log.Fatalln("error occurred attempting to parse SHUTDOWN_GRACE_PERIOD:", err)
-		}
-		if duration.Minutes() < 1 {
-			log.Fatalln("error occurred attempting to parse SHUTDOWN_GRACE_PERIOD. A value less than 1 was parsed:", duration.Minutes())
-		}
-		shutdownGracePeriod = duration
-		log.Infoln("Parsed SHUTDOWN_GRACE_PERIOD:", shutdownGracePeriod)
-	}
-	log.Infoln("Setting shutdown grace period to:", shutdownGracePeriod)
 
 	// Parse incoming check daemonset name
 	checkDSName = defaultCheckDSName

--- a/cmd/daemonset-check/main.go
+++ b/cmd/daemonset-check/main.go
@@ -39,6 +39,7 @@ var (
 
 	// Check time limit from injected env variable KH_CHECK_RUN_DEADLINE
 	checkTimeLimit time.Duration
+	checkTimeout   time.Duration
 
 	// Daemonset check configurations
 	hostName      string
@@ -92,7 +93,7 @@ func main() {
 
 	// create a context for our check to operate on that represents the timelimit the check has
 	log.Debugln("Allowing this check", checkTimeLimit, "to finish.")
-	ctx, ctxCancel := context.WithTimeout(context.Background(), checkTimeLimit)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), checkTimeout)
 
 	// Create a kubernetes client.
 	var err error

--- a/cmd/daemonset-check/main.go
+++ b/cmd/daemonset-check/main.go
@@ -128,9 +128,10 @@ func main() {
 		}
 		log.Infoln("Done running daemonset check")
 	case <-signalChan:
-		log.Infoln("Received shutdown signal. Canceling context and proceeding directly to cleanup.")
-		reportErrorsToKuberhealthy([]string{"kuberhealthy/daemonset: " + "Received shutdown signal. Canceling context " +
-			"and proceeding directly to cleanup."})
+		// TO DO: figure out better way to report shutdown signals. Do we report "error" or "ok" to kuberhealthy when
+		// a shutdown signal is received? For now, report OK and wait for the next run. 
+		reportOKToKuberhealthy()
+		log.Errorln("Received shutdown signal. Canceling context and proceeding directly to cleanup.")
 		ctxCancel() // Causes all functions within the check to return without error and abort. NOT an error
 	}
 

--- a/cmd/daemonset-check/run_check.go
+++ b/cmd/daemonset-check/run_check.go
@@ -77,9 +77,9 @@ func deploy(ctx context.Context) error {
 			return fmt.Errorf("error waiting for pods to come online: %s", err)
 		}
 		log.Infoln("Successfully deployed daemonset.")
-	case <-time.After(checkTimeLimit):
+	case <- time.After(checkDeadline.Sub(now)):
 		log.Debugln("nodes missing DS pods:", nodesMissingDSPod)
-		return errors.New("Reached check pod timeout: " + checkTimeLimit.String() + " waiting for all pods to come online. " +
+		return errors.New("Reached check pod timeout: " + checkDeadline.Sub(now).String() + " waiting for all pods to come online. " +
 			"Node(s) missing daemonset pod: " + formatNodes(nodesMissingDSPod))
 	case <-ctx.Done():
 		return errors.New("failed to complete check due to an interrupt signal. canceling deploying daemonset and shutting down from interrupt")
@@ -114,8 +114,8 @@ func remove(dsName string, ctx context.Context) error {
 			return fmt.Errorf("error trying to delete daemonset: %s", err)
 		}
 		log.Infoln("Successfully requested daemonset removal.")
-	case <-time.After(checkTimeLimit):
-		return errors.New("Reached check pod timeout: " + checkTimeLimit.String() + " waiting for daemonset removal command to complete.")
+	case <-time.After(checkDeadline.Sub(now)):
+		return errors.New("Reached check pod timeout: " + checkDeadline.Sub(now).String() + " waiting for daemonset removal command to complete.")
 	case <-ctx.Done():
 		// If there is a cancellation interrupt signal.
 		return errors.New("failed to complete check due to shutdown signal. canceling daemonset removal and shutting down from interrupt")
@@ -134,8 +134,8 @@ func remove(dsName string, ctx context.Context) error {
 			return fmt.Errorf("error waiting for daemonset removal: %s", err)
 		}
 		log.Infoln("Successfully removed daemonset.")
-	case <-time.After(checkTimeLimit):
-		return errors.New("Reached check pod timeout: " + checkTimeLimit.String() + " waiting for daemonset removal.")
+	case <-time.After(checkDeadline.Sub(now)):
+		return errors.New("Reached check pod timeout: " + checkDeadline.Sub(now).String() + " waiting for daemonset removal.")
 	case <-ctx.Done():
 		// If there is a cancellation interrupt signal.
 		return errors.New("failed to complete check due to an interrupt signal. canceling removing daemonset and shutting down from interrupt")
@@ -154,9 +154,9 @@ func remove(dsName string, ctx context.Context) error {
 			return fmt.Errorf("error waiting for daemonset pods removal: %s", err)
 		}
 		log.Infoln("Successfully removed daemonset pods.")
-	case <-time.After(checkTimeLimit):
+	case <-time.After(checkDeadline.Sub(now)):
 		unClearedDSPodsNodes := getDSPodsNodeList(podRemovalList)
-		return errors.New("reached check pod timeout: " + checkTimeLimit.String() + " waiting for daemonset pods removal. " + "Node(s) failing to remove daemonset pod: " + unClearedDSPodsNodes)
+		return errors.New("reached check pod timeout: " + checkDeadline.Sub(now).String() + " waiting for daemonset pods removal. " + "Node(s) failing to remove daemonset pod: " + unClearedDSPodsNodes)
 	case <-ctx.Done():
 		return errors.New("failed to complete check due to an interrupt signal. canceling removing daemonset pods and shutting down from interrupt")
 	}
@@ -173,7 +173,7 @@ func waitForPodsToComeOnline(ctx context.Context) error {
 	var counter int
 
 	// init a timeout for this whole deletion of daemonsets
-	log.Infoln("Timeout set:", checkTimeLimit.String(), "for all daemonset pods to come online")
+	log.Infoln("Timeout set:", checkDeadline.Sub(now).String(), "for all daemonset pods to come online")
 
 	for {
 		select {


### PR DESCRIPTION
…imit

Found a bug where ctxCancel has the same timeout as checkTimeLimit so the ctx.Done() is always called at the same time as  time.After(CheckTimeLimit) during our `waitFor...`