### PR TITLE
Add volumes to kuberhealthy deployment config

### DIFF
--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
           requests:
             cpu: {{ .Values.resources.requests.cpu }}
             memory: {{ .Values.resources.requests.memory }}
+      volumes:
+      - configMap:
+          name: kuberhealthy
+        name: config-volume
       {{- if .Values.deployment.nodeSelector }}
       nodeSelector:
 {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}


### PR DESCRIPTION
I think we were missing the `volumes` for the configmap! @jdowni000 