### PR TITLE
Network check patch for node check

### DIFF
--- a/cmd/network-connection-check/Makefile
+++ b/cmd/network-connection-check/Makefile
@@ -1,5 +1,7 @@
 build:
-	docker build -t kuberhealthy/network-connection-check:v0.1.0 -f Dockerfile ../../
+	docker build -t kuberhealthy/network-connection-check:v0.1.1 -f Dockerfile ../../
+	# docker build -t jonnydawg/network-connection-check:v0.1.12 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/network-connection-check:v0.1.0
+	docker push kuberhealthy/network-connection-check:v0.1.1
+	# docker push jonnydawg/network-connection-check:v0.1.12

--- a/cmd/network-connection-check/Makefile
+++ b/cmd/network-connection-check/Makefile
@@ -1,7 +1,5 @@
 build:
 	docker build -t kuberhealthy/network-connection-check:v0.1.1 -f Dockerfile ../../
-	# docker build -t jonnydawg/network-connection-check:v0.1.12 -f Dockerfile ../../
 
 push:
 	docker push kuberhealthy/network-connection-check:v0.1.1
-	# docker push jonnydawg/network-connection-check:v0.1.12

--- a/cmd/network-connection-check/failedNetworkConnectionCheck.yaml
+++ b/cmd/network-connection-check/failedNetworkConnectionCheck.yaml
@@ -14,6 +14,6 @@ spec:
           # Should we expect the connection target to fail to connect?  If so, set `CONNECTION_TARGET_UNREACHABLE` to `true`.
           - name: CONNECTION_TARGET_UNREACHABLE
             value: "true"
-        image: kuberhealthy/network-connection-check:v0.1.0
+        image: kuberhealthy/network-connection-check:v0.1.1
         name: kuberhealthy-metadata-unreachable
 

--- a/cmd/network-connection-check/main.go
+++ b/cmd/network-connection-check/main.go
@@ -14,7 +14,9 @@
 package main
 
 import (
+	"context"
 	"errors"
+	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -29,13 +31,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	checkclient "github.com/Comcast/kuberhealthy/v2/pkg/checks/external/checkclient"
+	"github.com/Comcast/kuberhealthy/v2/pkg/checks/external/nodeCheck"
 	"github.com/Comcast/kuberhealthy/v2/pkg/kubeClient"
 )
 
-var kubeConfigFile = os.Getenv("KUBECONFIG")
-var checkTimeout time.Duration
-var connectionTarget string
-var targetUnreachable bool
+var (
+	kubeConfigFile    = os.Getenv("KUBECONFIG")
+	checkTimeout      time.Duration
+	connectionTarget  string
+	targetUnreachable bool
+	checkNamespace    string
+	ctx               context.Context
+)
+
+const (
+	errorMessage = "Failed to complete network connection check in time! Timeout was reached."
+)
 
 // Checker validates that DNS is functioning correctly
 type Checker struct {
@@ -48,18 +59,15 @@ func init() {
 
 	var err error
 
-	// Grab and verify environment variables and set them as global vars
-	CheckTimeout := os.Getenv("CONNECTION_TIMEOUT")
-	if len(CheckTimeout) == 0 {
-		CheckTimeout = "20s"
-		log.Infoln("CONNECTION_TIMEOUT environment variable has not been set. Use", CheckTimeout, "as default timeout.")
-	}
-
-	checkTimeout, err = time.ParseDuration(CheckTimeout)
+	// Set check time limit to default
+	checkTimeout = time.Duration(time.Second * 20)
+	// Get the deadline time in unix from the env var
+	timeDeadline, err := checkclient.GetDeadline()
 	if err != nil {
-		log.Errorln("Error parsing timeout for check", CheckTimeout, err)
-		return
+		log.Infoln("There was an issue getting the check deadline:", err.Error())
 	}
+	checkTimeout = timeDeadline.Sub(time.Now().Add(time.Second * 5))
+	log.Infoln("Check time limit set to:", checkTimeout)
 
 	connectionTarget = os.Getenv("CONNECTION_TARGET")
 	if len(connectionTarget) == 0 {
@@ -69,10 +77,20 @@ func init() {
 
 	targetUnreachable, err = strconv.ParseBool(os.Getenv("CONNECTION_TARGET_UNREACHABLE"))
 	if err != nil {
-		log.Infoln("CONNECTION_TARGET_UNREACHABLE could not parsed.")
+		log.Infoln("CONNECTION_TARGET_UNREACHABLE could not be parsed.")
 		return
 	}
 
+	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		log.Warnln("Failed to open namespace file:", err.Error())
+	}
+	if len(data) != 0 {
+		log.Infoln("Found pod namespace:", string(data))
+		checkNamespace = string(data)
+	}
+
+	nodeCheck.EnableDebugOutput()
 }
 
 func main() {
@@ -84,7 +102,11 @@ func main() {
 	// create a new network connection checker
 	ncc := New()
 
-	err = ncc.Run(client)
+	ctx = context.Background()
+
+	// wait for the node to join the worker pool
+	waitForNodeToJoin(ctx, client, &checkNamespace)
+	err = ncc.Run(ctx, client)
 	if err != nil {
 		log.Errorln("Error running network connection check for:", connectionTarget)
 	}
@@ -100,10 +122,11 @@ func New() *Checker {
 }
 
 // Run implements the entrypoint for check execution
-func (ncc *Checker) Run(client *kubernetes.Clientset) error {
+func (ncc *Checker) Run(ctx context.Context, client *kubernetes.Clientset) error {
 	log.Infoln("Running network connection checker")
 
 	doneChan := make(chan error)
+	runTimeout := time.After(checkTimeout)
 
 	ncc.client = client
 	// run the check in a goroutine and notify the doneChan when completed
@@ -114,17 +137,22 @@ func (ncc *Checker) Run(client *kubernetes.Clientset) error {
 
 	// wait for either a timeout or job completion
 	select {
-	case <-time.After(checkTimeout + (2000 * time.Millisecond)):
+	// case <-time.After(checkTimeout + (2000 * time.Millisecond)):
 
-		// The check has timed out after its specified timeout period
-		errorMessage := "Failed to complete network connection check in time! Timeout was reached."
+	// 	// The check has timed out after its specified timeout period
 
-		err := checkclient.ReportFailure([]string{errorMessage})
-		if err != nil {
-			log.Println("Error reporting failure to Kuberhealthy servers:", err)
-			return err
-		}
-		return err
+	// 	err := checkclient.ReportFailure([]string{errorMessage})
+	// 	if err != nil {
+	// 		log.Println("Error reporting failure to Kuberhealthy servers:", err)
+	// 		return err
+	// 	}
+	// 	return err
+	case <-ctx.Done():
+		log.Println("Cancelling check and shutting down due to interrupt.")
+		return reportKHFailure("Cancelling check and shutting down due to interrupt.")
+	case <-runTimeout:
+		log.Println("Cancelling check and shutting down due to timeout.")
+		return reportKHFailure("Failed to complete network connection check in time! Timeout was reached.")
 	case err := <-doneChan:
 		if err != nil && ncc.targetUnreachable != true {
 			return reportKHFailure(err.Error())
@@ -188,4 +216,20 @@ func reportKHFailure(errorMessage string) error {
 	}
 	log.Println("Successfully reported failure to Kuberhealthy servers")
 	return err
+}
+
+// waitForNodeToJoin waits for the node to join the worker pool.
+// Waits for kube-proxy to be ready and that Kuberhealthy is reachable.
+func waitForNodeToJoin(ctx context.Context, client *kubernetes.Clientset, namespace *string) {
+	// Wait for node to be at least 2m old.
+	err := nodeCheck.WaitForNodeAge(ctx, client, *namespace, time.Minute*2)
+	if err != nil {
+		log.Errorln("Failed to check node age:", err.Error())
+	}
+
+	// Check if Kuberhealthy is reachable.
+	err = nodeCheck.WaitForKuberhealthy(ctx)
+	if err != nil {
+		log.Errorln("Failed to reach Kuberhealthy:", err.Error())
+	}
 }

--- a/cmd/network-connection-check/main.go
+++ b/cmd/network-connection-check/main.go
@@ -212,7 +212,7 @@ func reportKHFailure(errorMessage string) error {
 // Waits for kube-proxy to be ready and that Kuberhealthy is reachable.
 func waitForNodeToJoin(ctx context.Context, client *kubernetes.Clientset, namespace *string) {
 	// Wait for node to be at least 2m old.
-	err := nodeCheck.WaitForNodeAge(ctx, client, *namespace, time.Minute*2)
+	err := nodeCheck.WaitForNodeAge(ctx, client, *namespace, time.Minute*5)
 	if err != nil {
 		log.Errorln("Failed to check node age:", err.Error())
 	}

--- a/cmd/network-connection-check/main.go
+++ b/cmd/network-connection-check/main.go
@@ -137,16 +137,6 @@ func (ncc *Checker) Run(ctx context.Context, client *kubernetes.Clientset) error
 
 	// wait for either a timeout or job completion
 	select {
-	// case <-time.After(checkTimeout + (2000 * time.Millisecond)):
-
-	// 	// The check has timed out after its specified timeout period
-
-	// 	err := checkclient.ReportFailure([]string{errorMessage})
-	// 	if err != nil {
-	// 		log.Println("Error reporting failure to Kuberhealthy servers:", err)
-	// 		return err
-	// 	}
-	// 	return err
 	case <-ctx.Done():
 		log.Println("Cancelling check and shutting down due to interrupt.")
 		return reportKHFailure("Cancelling check and shutting down due to interrupt.")

--- a/cmd/network-connection-check/successedNetworkConnectionCheck.yaml
+++ b/cmd/network-connection-check/successedNetworkConnectionCheck.yaml
@@ -13,6 +13,6 @@ spec:
             value: "10s"
           - name: CONNECTION_TARGET
             value: "tcp://github.com:443"
-        image: kuberhealthy/network-connection-check:v0.1.0
+        image: kuberhealthy/network-connection-check:v0.1.1
         name: kuberhealthy-github-reachable
 

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -118,7 +118,7 @@ check:
     timeout: 10m
     image:
       repository: kuberhealthy/network-connection-check
-      tag: v0.1.0
+      tag: v0.1.1
     extraEnvs:
       CONNECTION_TARGET: "tcp://github.com:443"
     nodeSelector: {}


### PR DESCRIPTION
Added node check -- waits for node to be 5m old and that Kuberhealthy is reachable.

Also refactored to respect a `ctx` in some areas.

---

There was an issue where this check would sometimes get scheduled on a new node, before kube-proxy was available -- this attempts to address that.