### PR TITLE
Add resources.limits Deployment template

### DIFF
--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
           requests:
             cpu: {{ .Values.resources.requests.cpu }}
             memory: {{ .Values.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
       {{- if .Values.deployment.nodeSelector }}
       nodeSelector:
 {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}

--- a/deploy/kuberhealthy-prometheus-operator.yaml
+++ b/deploy/kuberhealthy-prometheus-operator.yaml
@@ -423,6 +423,9 @@ spec:
           requests:
             cpu: 400m
             memory: 300Mi
+          limits:
+            cpu: 2
+            memory: 1Gi
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
 ---

--- a/deploy/kuberhealthy-prometheus.yaml
+++ b/deploy/kuberhealthy-prometheus.yaml
@@ -426,6 +426,9 @@ spec:
           requests:
             cpu: 400m
             memory: 300Mi
+          limits:
+            cpu: 2
+            memory: 1Gi
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
 ---

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -394,6 +394,9 @@ spec:
           requests:
             cpu: 400m
             memory: 300Mi
+          limits:
+            cpu: 2
+            memory: 1Gi
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
 ---


### PR DESCRIPTION
Currently, the values file suggests that resources.limits can be set by these lines: https://github.com/Comcast/kuberhealthy/blob/master/deploy/helm/kuberhealthy/values.yaml#L21-L23

However, the current Deployment template does not ever use these resources.limits values, and only uses resources.requests as shown here: https://github.com/Comcast/kuberhealthy/blob/master/deploy/helm/kuberhealthy/templates/deployment.yaml#L89-L92

The Deployment template should be able to configure limits.cpu and limits.memory from the values file.

The other three static manifests that contain the same Deployment should likely also have these resources.limits values, since they do not have any limits as of now. I obtained the specific values from the the Helm chart's values.yaml, the first link above.