### PR TITLE
move defaults to unprivileged contianers

### DIFF
--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 IMAGE="kuberhealthy/deployment-check"
-TAG="v1.5.1"
+TAG="v1.6.0"
 
 build:
 	docker build -t ${IMAGE}:${TAG} -f Dockerfile ../../

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -2,7 +2,7 @@
 
 This check tests if a `deployment` and `service` can be created within your Kubernetes cluster. It will attempt to bring up a `deployment` with `2` replicas and a `service` of type `ClusterIP` in the `kuberhealthy` namespace and waits for the pods to come up. Once the `deployment` is ready, the check makes a request to the hostname looking for a `200 OK`. The check then proceeds to terminate them and ensures that the deployment and service terminations were successful. A complete tear down of the `deployment` and `service` after receiving a `200 OK` marks a successful test run.
 
-Container resource requests are set to `15 millicores` of CPU and `20Mi` units of memory and use the Nginx's latest image `nginx:latest` for the deployment. If the environment variable `CHECK_DEPLOYMENT_ROLLING_UPDATE` is set to `true`, the check will attempt to perform a rolling-update on the `deployment`. Once this rolling-update completes, the check makes another request to the hostname looking for a `200 OK` again before cleaning up. By default, the check will initially deploy Nginx's `nginx:1.17.8` image, and update to `nginx:1.17.9`.
+Container resource requests are set to `15 millicores` of CPU and `20Mi` units of memory and use the Nginx's latest image `nginx:latest` for the deployment. If the environment variable `CHECK_DEPLOYMENT_ROLLING_UPDATE` is set to `true`, the check will attempt to perform a rolling-update on the `deployment`. Once this rolling-update completes, the check makes another request to the hostname looking for a `200 OK` again before cleaning up. By default, the check will initially deploy Nginx's unprivileged `nginxinc/nginx-unprivileged:1.17.8` image, and update to `nginxinc/nginx-unprivileged:1.17.8`.
 
 Custom images can be used for this check and can be specified with the `CHECK_IMAGE` and `CHECK_IMAGE_ROLL_TO` environment variables. If a custom image requires the use of environment variables, they can be passed down into your container by setting the environment variable `ADDITIONAL_ENV_VARS` to a string of comma-separated values (`"X=foo,Y=bar"`).
 
@@ -34,8 +34,8 @@ __IF ROLLING-UPDATE OPTION IS ENABLED__
 - Check Interval: 30 minutes
 - Check name: `deployment`
 - Configurable check environment variables:
-  - `CHECK_IMAGE`: Initial container image. (default=`nginx:1.17.8`)
-  - `CHECK_IMAGE_ROLL_TO`: Container image to roll to. (default=`nginx:1.17.9`)
+  - `CHECK_IMAGE`: Initial container image. (default=`nginxinc/nginx-unprivileged:1.17.8`)
+  - `CHECK_IMAGE_ROLL_TO`: Container image to roll to. (default=`nginxinc/nginx-unprivileged:1.17.9`)
   - `CHECK_DEPLOYMENT_NAME`: Name for the check's deployment. (default=`deployment-deployment`)
   - `CHECK_SERVICE_NAME`: Name for the check's service. (default=`deployment-svc`)
   - `CHECK_NAMESPACE`: Namespace for the check (default=`kuberhealthy`).

--- a/cmd/deployment-check/main.go
+++ b/cmd/deployment-check/main.go
@@ -120,11 +120,11 @@ const (
 	defaultCheckContainerName = "deployment-container"
 
 	// Default images used for check.
-	defaultCheckImageURL  = "nginx:1.17.8"
-	defaultCheckImageURLB = "nginx:1.17.9"
+	defaultCheckImageURL  = "nginxinc/nginx-unprivileged:1.17.8"
+	defaultCheckImageURLB = "nginxinc/nginx-unprivileged:1.17.9"
 
 	// Default container port used for check.
-	defaultCheckContainerPort = int32(80)
+	defaultCheckContainerPort = int32(8080)
 
 	// Default load balancer port used for check.
 	defaultCheckLoadBalancerPort = int32(80)


### PR DESCRIPTION
Addresses #601 

Moves default container to unprivileged nginx images [`nginxinc/nginx-unprivileged:1.17.8`, `nginxinc/nginx-unprivileged:1.17.9`] and default port to `8080`.

Image changes:
```
nginx:1.17.8 -> nginxinc/nginx-unprivileged:1.17.8
nginx:1.17.9 -> nginxinc/nginx-unprivileged:1.17.9
```

Port changes:
```
80 -> 8080
```