### PR TITLE
base cve changes for kuberhealthy image

### DIFF
--- a/cmd/kuberhealthy/Dockerfile
+++ b/cmd/kuberhealthy/Dockerfile
@@ -18,7 +18,7 @@ RUN groupadd -g 999 kuberhealthy && useradd -r -u 999 -g kuberhealthy kuberhealt
 FROM scratch
 WORKDIR /app
 COPY --from=builder /kuberhealthy/ /app
-
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 USER kuberhealthy
 EXPOSE 80

--- a/cmd/kuberhealthy/Dockerfile
+++ b/cmd/kuberhealthy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as builder
+FROM golang:latest as builder
 LABEL LOCATION="git@github.com:Comcast/kuberhealthy.git"
 LABEL DESCRIPTION="Kuberhealthy - Check and expose kubernetes cluster health in detail."
 RUN mkdir /kuberhealthy
@@ -13,13 +13,13 @@ ENV CGO_ENABLED=0
 #RUN go test -v -short -- --debug --forceMaster
 RUN go build -v -o kuberhealthy
 RUN mv kuberhealthy /kuberhealthy/kuberhealthy
+RUN groupadd -g 999 kuberhealthy && useradd -r -u 999 -g kuberhealthy kuberhealthy
 
-FROM golang:1.13
-RUN apt-get update && apt-get upgrade -y && apt-get remove mercurial -y && rm -rf /var/lib/apt/lists/*
+FROM scratch
 WORKDIR /app
 COPY --from=builder /kuberhealthy/ /app
 
-RUN groupadd -g 999 kuberhealthy && useradd -r -u 999 -g kuberhealthy kuberhealthy
+COPY --from=builder /etc/passwd /etc/passwd
 USER kuberhealthy
 EXPOSE 80
 ENTRYPOINT /app/kuberhealthy

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -1,5 +1,5 @@
 IMAGE="kuberhealthy/kuberhealthy"
-TAG="v2.3.1-alpha"
+TAG="v2.3.1"
 
 build:
 	docker build --no-cache --pull -t ${IMAGE}:${TAG} -f Dockerfile ../../

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -1,8 +1,8 @@
 IMAGE="kuberhealthy/kuberhealthy"
-TAG="v2.3.0"
+TAG="v2.3.1"
 
 build:
-	docker build -t ${IMAGE}:${TAG} -f Dockerfile ../../
+	docker build --no-cache --pull -t ${IMAGE}:${TAG} -f Dockerfile ../../
 build-dev:
 	docker build -t kuberhealthy:dev -f Dockerfile ../../
 push:

--- a/cmd/kuberhealthy/Makefile
+++ b/cmd/kuberhealthy/Makefile
@@ -1,5 +1,5 @@
 IMAGE="kuberhealthy/kuberhealthy"
-TAG="v2.3.1"
+TAG="v2.3.1-alpha"
 
 build:
 	docker build --no-cache --pull -t ${IMAGE}:${TAG} -f Dockerfile ../../


### PR DESCRIPTION
Replaces base image to `scratch`.
Change build step with `--no-cache` and `--pull` to force rebuild of layers and pulling of latest Docker base image.