### PR TITLE
fix: remove unused variable enableScraping

### DIFF
--- a/.ci/values.yaml
+++ b/.ci/values.yaml
@@ -6,7 +6,6 @@ prometheus:
   enabled: false
   name: "prometheus"
   release: prometheus-operator
-  enableScraping: false
   serviceMonitor: false
   enableAlerting: false
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,12 +47,12 @@ A helm chart for deploying Kuberhealthy.  This is the same helm chart published 
 
   - Without Prometheus:
   `helm install kuberhealthy kuberhealthy/kuberhealthy`
-  
+
   - With Prometheus:
-  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true --set prometheus.enableScraping=true --set prometheus.enableAlerting=true`
- 
- - With Prometheus Operator:
-  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true --set prometheus.enableScraping=true --set prometheus.enableAlerting=true --set prometheus.serviceMonitor=true`
+  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true`
+
+  - With Prometheus Operator:
+  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true --set prometheus.serviceMonitor=true`
 
 
 ### Helm

--- a/deploy/helm/create-flat-files.sh
+++ b/deploy/helm/create-flat-files.sh
@@ -11,10 +11,10 @@ echo "Creating flat kuberhealthy.yaml"
 $HELM template --namespace kuberhealthy kuberhealthy > ../kuberhealthy.yaml
 
 echo "Creating flat kuberhealthy-prometheus.yaml"
-$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true --set prometheus.enableScraping=true --set prometheus.enableAlerting=true > ../kuberhealthy-prometheus.yaml
+$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true > ../kuberhealthy-prometheus.yaml
 
 echo "Creating flat kuberhealthy-prometheus-operator.yaml"
-$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true --set prometheus.enableScraping=true --set prometheus.enableAlerting=true --set prometheus.serviceMonitor=true > ../kuberhealthy-prometheus-operator.yaml
+$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true --set prometheus.serviceMonitor=true > ../kuberhealthy-prometheus-operator.yaml
 
 
 # temp helm fix described in issue #279:

--- a/deploy/helm/kuberhealthy/NOTES.txt
+++ b/deploy/helm/kuberhealthy/NOTES.txt
@@ -7,7 +7,7 @@ Kuberhealthy has been installed to your cluster!
 	Service Port: {{ .Values.service.externalPort }}
 	Tolerates Masters: {{ .Values.tolerations.master }}
 {{- if .Values.prometheus.enabled -}}
-	Prometheus Scraping: {{ .Values.prometheus.enableScraping }}
+	Prometheus Enabled: {{ .Values.prometheus.enabled }}
 	Prometheus Alerting: {{ .Values.prometheus.enableAlerting }}
 {{- end -}}
 

--- a/deploy/helm/kuberhealthy/README.md
+++ b/deploy/helm/kuberhealthy/README.md
@@ -30,7 +30,6 @@ It is possible to configure Kuberhealthy's Prometheus integration with Helm vari
 prometheus:
   enabled: true # do we deploy a ServiceMonitor spec?
   name: "prometheus" # the name of the Prometheus deployment in your environment.
-  enableScraping: true # add the Prometheus scrape annotation to Kuberhealthy pods
   serviceMonitor: false # use a ServiceMonitor configuration, for if using Prometheus Operator
   enableAlerting: true # enable default Kuberhealthy alerts configuration
 app:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -6,7 +6,6 @@ prometheus:
   enabled: false
   name: "prometheus"
   release: prometheus-operator
-  enableScraping: false
   serviceMonitor: false
   enableAlerting: false
 

--- a/docs/K8s-KPIs-with-Kuberhealthy.md
+++ b/docs/K8s-KPIs-with-Kuberhealthy.md
@@ -22,12 +22,12 @@ in this [deploy folder](https://github.com/Comcast/kuberhealthy/tree/master/depl
 
   - If you use the [Prometheus Operator](https://github.com/coreos/prometheus-operator):
   ```
-  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.enableAlerting=true,prometheus.enableScraping=true,prometheus.serviceMonitor=true
+  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.enableAlerting=true,prometheus.serviceMonitor=true
   ```
 
   - If you use Prometheus, but NOT Prometheus Operator:
   ```
-  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.enableAlerting=true,prometheus.enableScraping=true
+  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.enableAlerting=true
   ```
    See additional details about configuring the appropriate scrape annotations in the section [Prometheus Integration Details](#prometheus-integration-details) below.
 


### PR DESCRIPTION
* enableScraping is not used in helm template || should be delated
* update docs based on these changes
* additional minor change: make "With Prometheus Operator:" is under "Install kuberhealthy with Helm using one of the following..."