### PR TITLE
modify version references for kind in e2e workflow to latest

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,9 +20,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: build container
       run: docker build --file cmd/kuberhealthy/Dockerfile --tag kuberhealthy:$GITHUB_RUN_ID .
-    - uses: engineerd/setup-kind@v0.3.0
+    - uses: engineerd/setup-kind@v0.4.0
       with:
-          version: "v0.7.0"
+          version: "v0.8.1"
 
     - name: Testing
       run: |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ With Kuberhealthy, you can easily create synthetic tests to check your applicati
 
 After installation, Kuberhealthy will only be available from within the cluster (`Type: ClusterIP`) at the service URL `kuberhealthy.kuberhealthy`.  To expose Kuberhealthy to an external checking service, you **must** edit the service `kuberhealthy` and set `Type: LoadBalancer`.  This is done for security.  Options are available in the Helm chart to bypass this and deploy with `Type: LoadBalancer` directly.
 
-Kuberhealthy is currently tested on Kubernetes `1.9.x`, to `1.15.x`.
+Kuberhealthy is currently tested on Kubernetes `1.9.x`, to `1.18.x`.
 
 More installation options, including static yaml files are available in the [/deploy](/deploy) directory.  To configure Kuberhealthy after installation, see the [configuration documentation](https://github.com/Comcast/kuberhealthy/blob/config-readme/docs/CONFIGURATION.md).
 


### PR DESCRIPTION
setup-kind action v0.4.0 and kind v.0.8.1.

e2e workflow tested successfully at https://github.com/cdbitz/kuberhealthy/runs/1043631973?check_suite_focus=true , using node v1.18.2.