### PR TITLE
fixed scratch kuberhealthy build and prevented NPE when creating dynamic client

### DIFF
--- a/cmd/kuberhealthy/Dockerfile
+++ b/cmd/kuberhealthy/Dockerfile
@@ -1,25 +1,19 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 LABEL LOCATION="git@github.com:Comcast/kuberhealthy.git"
 LABEL DESCRIPTION="Kuberhealthy - Check and expose kubernetes cluster health in detail."
-RUN mkdir /kuberhealthy
-
-WORKDIR /go/src/github.com/Comcast/kuberhealthy/
-COPY go.* ./
-RUN go mod download
-COPY ./ ./
-WORKDIR /go/src/github.com/Comcast/kuberhealthy/cmd/kuberhealthy
+COPY . /build
+WORKDIR /build/cmd/kuberhealthy
 ENV CGO_ENABLED=0
-# RUN go version
+RUN go version
 #RUN go test -v -short -- --debug --forceMaster
-RUN go build -v -o kuberhealthy
-RUN mv kuberhealthy /kuberhealthy/kuberhealthy
-RUN groupadd -g 999 kuberhealthy && useradd -r -u 999 -g kuberhealthy kuberhealthy
+RUN mkdir /app
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
+RUN go build -v -o /app/kuberhealthy
 
 FROM scratch
 WORKDIR /app
-COPY --from=builder /kuberhealthy/ /app
+COPY --from=builder /app /app
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
-USER kuberhealthy
-EXPOSE 80
-ENTRYPOINT /app/kuberhealthy
+ENTRYPOINT ["/app/kuberhealthy"]


### PR DESCRIPTION
This fixes the scratch image for Kuberhealthy so that it properly starts without complaining that `/bin/sh` is missing.   I also found a null pointer exception to fix as well.
