### PR TITLE
add more options for check-reaper cj

### DIFF
--- a/deploy/helm/kuberhealthy/Chart.yaml
+++ b/deploy/helm/kuberhealthy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kuberhealthy
 appVersion: 2.2.0
-version: 2.2.1
+version: 2.2.2
 home: https://comcast.github.io/kuberhealthy/
 description: "An operator for synthetic test and monitoring. Works great with Prometheus."
 type: application

--- a/deploy/helm/kuberhealthy/templates/check-reaper.yaml
+++ b/deploy/helm/kuberhealthy/templates/check-reaper.yaml
@@ -26,6 +26,9 @@ spec:
           restartPolicy: OnFailure
           serviceAccountName: check-reaper
   concurrencyPolicy: Forbid
+  {{- if .Values.checkReaper.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.checkReaper.startingDeadlineSeconds }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -128,3 +128,4 @@ checkReaper:
     repository: kuberhealthy/check-reaper
     tag: v1.4.0
   nodeSelector: {}
+  # startingDeadlineSeconds:


### PR DESCRIPTION
- added `startingDeadlineSeconds` to check-reaper's cronjob template

I've been running into issues where the check-reaper has too many missed schedules for whatever reason. I figured adding this is harmless and gives the user an option to configure this without having to patch manually. 