### PR TITLE
Support custom tolerations

### DIFF
--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -99,9 +99,14 @@ spec:
       {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
-{{- if .Values.tolerations.master }}
+{{- if or .Values.tolerations.master .Values.deployment.tolerations }}
       tolerations:
+{{- end }}
+{{- if .Values.tolerations.master }}
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
-{{- end -}}
+{{- end }}
+{{- if .Values.deployment.tolerations }}
+      {{- toYaml .Values.deployment.tolerations | nindent 6 }}
+{{- end }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -39,6 +39,11 @@ deployment:
   imagePullPolicy: IfNotPresent
   nodeSelector: {}
   podAnnotations: {}
+  # tolerations:
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
   env: {}
   command:
   - /app/kuberhealthy


### PR DESCRIPTION
Currently, this helm chart support only fixed toleration, but I want to add the custom tolerations to kuberhealty deployment.
So I added the `.Values.deployment.tolerations`.

Thanks