### PR TITLE
Allow setting a priorityClassName for DaemonSet check

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - [Babak Ghadiri](mailto:bbkghadiri6@gmail.com)
 - [Chris Hirsch](mailto:chris@base2technology.com)
 - [Adrian Aneci](mailto:aneci.adrian@gmail.com)
+- [Mike Tougeron](https://twitter.com/mtougeron)

--- a/cmd/daemonset-check/Makefile
+++ b/cmd/daemonset-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/daemonset-check:v3.1.1 -f Dockerfile ../../
+	docker build -t kuberhealthy/daemonset-check:v3.2.0 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/daemonset-check:v3.1.1
+	docker push kuberhealthy/daemonset-check:v3.2.0

--- a/cmd/daemonset-check/README.md
+++ b/cmd/daemonset-check/README.md
@@ -36,7 +36,7 @@ spec:
             value: "kuberhealthy"
           - name: NODE_SELECTOR # Schedules daemonsets only to nodes with this label
             value: "kubernetes.io/os=linux"
-        image: kuberhealthy/daemonset-check:v3.1.0
+        image: kuberhealthy/daemonset-check:v3.2.0
         imagePullPolicy: IfNotPresent
         name: main
         resources:
@@ -53,6 +53,7 @@ spec:
 |PAUSE_CONTAINER_IMAGE|"gcr.io/google-containers/pause:3.1"|
 |SHUTDOWN_GRACE_PERIOD|1m|
 |CHECK_DAEMONSET_NAME|"daemonset"|
+|DAEMONSET_PRIORITY_CLASS_NAME|""|
 |NODE_SELECTOR|`<none>`|
 
 #### Daemonset Check Diagram

--- a/cmd/daemonset-check/input.go
+++ b/cmd/daemonset-check/input.go
@@ -63,7 +63,7 @@ func parseInputValues() {
 	log.Infoln("Setting check daemonset name to:", checkDSName)
 
 	// Parse incoming check daemonset name
-	podPriorityClassName = defaultPodPriority
+	podPriorityClassName = defaultPodPriorityClassName
 	if len(podPriorityClassNameEnv) != 0 {
 		podPriorityClassName = podPriorityClassNameEnv
 		log.Infoln("Parsed PRIORITY_CLASS:", podPriorityClassName)

--- a/cmd/daemonset-check/input.go
+++ b/cmd/daemonset-check/input.go
@@ -62,6 +62,14 @@ func parseInputValues() {
 	}
 	log.Infoln("Setting check daemonset name to:", checkDSName)
 
+	// Parse incoming check daemonset name
+	podPriorityClassName = defaultPodPriority
+	if len(podPriorityClassNameEnv) != 0 {
+		podPriorityClassName = podPriorityClassNameEnv
+		log.Infoln("Parsed PRIORITY_CLASS:", podPriorityClassName)
+	}
+	log.Infoln("Setting check priority class name to:", podPriorityClassName)
+
 	// Parse incoming deployment node selectors
 	if len(dsNodeSelectorsEnv) != 0 {
 		splitEnvVars := strings.Split(dsNodeSelectorsEnv, ",")

--- a/cmd/daemonset-check/main.go
+++ b/cmd/daemonset-check/main.go
@@ -75,8 +75,8 @@ const (
 	defaultCheckDeadline = time.Duration(time.Minute * 15)
 	// Default user
 	defaultUser = int64(1000)
-	// Default priority class
-	defaultPodPriority = ""
+	// Default priority class name
+	defaultPodPriorityClassName = ""
 )
 
 func init() {

--- a/cmd/daemonset-check/main.go
+++ b/cmd/daemonset-check/main.go
@@ -42,6 +42,10 @@ var (
 	checkDSNameEnv = os.Getenv("CHECK_DAEMONSET_NAME")
 	checkDSName    string
 
+	// The priority class to use for the daemonset
+	podPriorityClassNameEnv = os.Getenv("DAEMONSET_PRIORITY_CLASS_NAME")
+	podPriorityClassName    string
+
 	// Check deadline from injected env variable KH_CHECK_RUN_DEADLINE
 	khDeadline    time.Time
 	checkDeadline time.Time
@@ -71,6 +75,8 @@ const (
 	defaultCheckDeadline = time.Duration(time.Minute * 15)
 	// Default user
 	defaultUser = int64(1000)
+	// Default priority class
+	defaultPodPriority = ""
 )
 
 func init() {

--- a/cmd/daemonset-check/run_check.go
+++ b/cmd/daemonset-check/run_check.go
@@ -386,6 +386,7 @@ func generateDaemonSetSpec() *appsv1.DaemonSet {
 				Spec: apiv1.PodSpec{
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 					Tolerations:                   []apiv1.Toleration{},
+					PriorityClassName:             podPriorityClassName,
 					Containers: []apiv1.Container{
 						{
 							Name:  "sleep",


### PR DESCRIPTION
This PR allows for you to optionally set a priorityClassName for the DaemonSet that is created in the check. This allows for preemption when some nodes are fully utilized. 

While preemption isn't ideal, knowing the state of the synthetic checks & overall cluster health are a priority workload.