### PR TITLE
chore: add an extra public function to create a state client, useful …

### DIFF
--- a/pkg/khstatecrd/api.go
+++ b/pkg/khstatecrd/api.go
@@ -61,3 +61,10 @@ func Client(GroupName string, GroupVersion string, kubeConfig string, namespace 
 	client, err := rest.RESTClientFor(&config)
 	return &KuberhealthyStateClient{restClient: client}, err
 }
+
+// // CreateClient returns a Kuberhealthy State client using an existing rest client
+func CreateClient(client rest.Interface) *KuberhealthyStateClient {
+	return &KuberhealthyStateClient{
+		restClient: client,
+	}
+}


### PR DESCRIPTION
…nts, useful if folks have authenticated and created a restclient outside of kuberhealthy.

FWIW we're working on a CLI plugin for Jenkins X which reports back on health check states from Kuberhealthy.  It's still wip and early days but it's coming along great, really loving Kuberhealthy :) 

We have a number of reusable libraries in Jenkins X land, one of which authenticates with a Kubernetes API server whether you're in or out of cluster https://github.com/jenkins-x/jx-kube-client#jx-kube-client.  We use this in the JX plugins so already have a Kubernetes REST client which we'd like to use to create the `KuberhealthyStateClient` and continue to use the Kuberhealthy APIs to query KH states.


