### PR TITLE
deployment-check: propagate context from entrypoint

### DIFF
--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -165,7 +165,7 @@ type DeploymentResult struct {
 }
 
 // createDeployment creates a deployment in the cluster with a given deployment specification.
-func createDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
+func createDeployment(ctx context.Context, deploymentConfig *v1.Deployment) chan DeploymentResult {
 
 	createChan := make(chan DeploymentResult)
 
@@ -176,7 +176,7 @@ func createDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
 
 		result := DeploymentResult{}
 
-		deployment, err := client.AppsV1().Deployments(checkNamespace).Create(context.TODO(), deploymentConfig, metav1.CreateOptions{})
+		deployment, err := client.AppsV1().Deployments(checkNamespace).Create(ctx, deploymentConfig, metav1.CreateOptions{})
 		if err != nil {
 			log.Infoln("Failed to create a deployment in the cluster:", err)
 			result.Err = err
@@ -195,7 +195,7 @@ func createDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
 			log.Infoln("Watching for deployment to exist.")
 
 			// Watch that it is up.
-			watch, err := client.AppsV1().Deployments(checkNamespace).Watch(context.TODO(), metav1.ListOptions{
+			watch, err := client.AppsV1().Deployments(checkNamespace).Watch(ctx, metav1.ListOptions{
 				Watch:         true,
 				FieldSelector: "metadata.name=" + deployment.Name,
 				// LabelSelector: defaultLabelKey + "=" + defaultLabelValueBase + strconv.Itoa(int(now.Unix())),
@@ -363,7 +363,7 @@ func deleteDeploymentAndWait(ctx context.Context) error {
 			time.Sleep(time.Second * 5)
 
 			// Watch that it is gone by listing repeatedly.
-			deploymentList, err := client.AppsV1().Deployments(checkNamespace).List(context.TODO(), metav1.ListOptions{
+			deploymentList, err := client.AppsV1().Deployments(checkNamespace).List(ctx, metav1.ListOptions{
 				FieldSelector: "metadata.name=" + checkDeploymentName,
 				// LabelSelector: defaultLabelKey + "=" + defaultLabelValueBase + strconv.Itoa(int(now.Unix())),
 			})
@@ -378,7 +378,7 @@ func deleteDeploymentAndWait(ctx context.Context) error {
 				// If the deployment exists, try to delete it.
 				if deploy.GetName() == checkDeploymentName {
 					deploymentExists = true
-					err = deleteDeployment()
+					err = deleteDeployment(ctx)
 					if err != nil {
 						log.Errorln("Error when running a delete on deployment", checkDeploymentName+":", err.Error())
 					}
@@ -396,7 +396,7 @@ func deleteDeploymentAndWait(ctx context.Context) error {
 	}()
 
 	// Send a delete on the deployment.
-	err := deleteDeployment()
+	err := deleteDeployment(ctx)
 	if err != nil {
 		log.Infoln("Could not delete deployment:", checkDeploymentName)
 	}
@@ -405,7 +405,7 @@ func deleteDeploymentAndWait(ctx context.Context) error {
 }
 
 // deleteDeployment issues a foreground delete for the check test deployment name.
-func deleteDeployment() error {
+func deleteDeployment(ctx context.Context) error {
 	log.Infoln("Attempting to delete deployment in", checkNamespace, "namespace.")
 	// Make a delete options object to delete the deployment.
 	deletePolicy := metav1.DeletePropagationForeground
@@ -416,11 +416,11 @@ func deleteDeployment() error {
 	}
 
 	// Delete the deployment and return the result.
-	return client.AppsV1().Deployments(checkNamespace).Delete(context.TODO(), checkDeploymentName, deleteOpts)
+	return client.AppsV1().Deployments(checkNamespace).Delete(ctx, checkDeploymentName, deleteOpts)
 }
 
 // cleanUpOrphanedDeployment cleans up deployments created from previous checks.
-func cleanUpOrphanedDeployment() error {
+func cleanUpOrphanedDeployment(ctx context.Context) error {
 
 	cleanUpChan := make(chan error)
 
@@ -428,7 +428,7 @@ func cleanUpOrphanedDeployment() error {
 		defer close(cleanUpChan)
 
 		// Watch that it is gone.
-		watch, err := client.AppsV1().Deployments(checkNamespace).Watch(context.TODO(), metav1.ListOptions{
+		watch, err := client.AppsV1().Deployments(checkNamespace).Watch(ctx, metav1.ListOptions{
 			Watch:         true,
 			FieldSelector: "metadata.name=" + checkDeploymentName,
 			// LabelSelector: defaultLabelKey + "=" + defaultLabelValueBase + strconv.Itoa(int(now.Unix())),
@@ -472,7 +472,7 @@ func cleanUpOrphanedDeployment() error {
 	}
 
 	// Send the delete request.
-	err := client.AppsV1().Deployments(checkNamespace).Delete(context.TODO(), checkDeploymentName, deleteOpts)
+	err := client.AppsV1().Deployments(checkNamespace).Delete(ctx, checkDeploymentName, deleteOpts)
 	if err != nil {
 		return errors.New("failed to delete previous deployment: " + err.Error())
 	}
@@ -482,11 +482,11 @@ func cleanUpOrphanedDeployment() error {
 
 // findPreviousDeployment lists deployments and checks their names and labels to determine if there should
 // be an old deployment belonging to this check that should be deleted.
-func findPreviousDeployment() (bool, error) {
+func findPreviousDeployment(ctx context.Context) (bool, error) {
 
 	log.Infoln("Attempting to find previously created deployment(s) belonging to this check.")
 
-	deploymentList, err := client.AppsV1().Deployments(checkNamespace).List(context.TODO(), metav1.ListOptions{})
+	deploymentList, err := client.AppsV1().Deployments(checkNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Infoln("error listing deployments:", err)
 		return false, err
@@ -530,7 +530,7 @@ func findPreviousDeployment() (bool, error) {
 
 // updateDeployment performs an update on a deployment with a given deployment configuration.  The DeploymentResult
 // channel is notified when the rolling update is complete.
-func updateDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
+func updateDeployment(ctx context.Context, deploymentConfig *v1.Deployment) chan DeploymentResult {
 
 	updateChan := make(chan DeploymentResult)
 
@@ -546,7 +546,7 @@ func updateDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
 		// oldPodNames := getPodNames()
 		// newPodStatuses := make(map[string]bool)
 
-		deployment, err := client.AppsV1().Deployments(checkNamespace).Update(context.TODO(), deploymentConfig, metav1.UpdateOptions{})
+		deployment, err := client.AppsV1().Deployments(checkNamespace).Update(ctx, deploymentConfig, metav1.UpdateOptions{})
 		if err != nil {
 			log.Infoln("Failed to update deployment in the cluster:", err)
 			result.Err = err
@@ -555,7 +555,7 @@ func updateDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
 		}
 
 		// Watch that it is up.
-		watch, err := client.AppsV1().Deployments(checkNamespace).Watch(context.TODO(), metav1.ListOptions{
+		watch, err := client.AppsV1().Deployments(checkNamespace).Watch(ctx, metav1.ListOptions{
 			Watch:         true,
 			FieldSelector: "metadata.name=" + deployment.Name,
 			// LabelSelector: defaultLabelKey + "=" + defaultLabelValueBase + strconv.Itoa(int(now.Unix())),
@@ -613,7 +613,7 @@ func updateDeployment(deploymentConfig *v1.Deployment) chan DeploymentResult {
 }
 
 // waitForDeploymentToDelete waits for the service to be deleted.
-func waitForDeploymentToDelete() chan bool {
+func waitForDeploymentToDelete(ctx context.Context) chan bool {
 
 	// Make and return a channel while we check that the service is gone in the background.
 	deleteChan := make(chan bool, 1)
@@ -621,7 +621,7 @@ func waitForDeploymentToDelete() chan bool {
 	go func() {
 		defer close(deleteChan)
 		for {
-			_, err := client.AppsV1().Deployments(checkNamespace).Get(context.TODO(), checkDeploymentName, metav1.GetOptions{})
+			_, err := client.AppsV1().Deployments(checkNamespace).Get(ctx, checkDeploymentName, metav1.GetOptions{})
 			if err != nil {
 				log.Debugln("error from Deployments().Get():", err.Error())
 				if k8sErrors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
@@ -639,10 +639,10 @@ func waitForDeploymentToDelete() chan bool {
 
 // rollingUpdateComplete checks the deployment's container images and their statuses and returns
 // a boolean based on whether or not the rolling-update is complete.
-func rollingUpdateComplete(statuses map[string]bool, oldPodNames []string) bool {
+func rollingUpdateComplete(ctx context.Context, statuses map[string]bool, oldPodNames []string) bool {
 
 	// Should be looking at pod and pod names NOT containers.
-	podList, err := client.CoreV1().Pods(checkNamespace).List(context.TODO(), metav1.ListOptions{
+	podList, err := client.CoreV1().Pods(checkNamespace).List(ctx, metav1.ListOptions{
 		// FieldSelector: "metadata.name=" + checkDeploymentName,
 		LabelSelector: defaultLabelKey + "=" + defaultLabelValueBase + strconv.Itoa(int(now.Unix())),
 	})
@@ -709,11 +709,11 @@ func deploymentAvailable(deployment *v1.Deployment) bool {
 }
 
 // getPodNames gets the current list of pod names -- used to reference for a completed rolling update.
-func getPodNames() []string {
+func getPodNames(ctx context.Context) []string {
 	names := make([]string, 0)
 
 	// Should be looking at pod and pod names NOT containers.
-	podList, err := client.CoreV1().Pods(checkNamespace).List(context.TODO(), metav1.ListOptions{
+	podList, err := client.CoreV1().Pods(checkNamespace).List(ctx, metav1.ListOptions{
 		// FieldSelector: "metadata.name=" + checkDeploymentName,
 		LabelSelector: defaultLabelKey + "=" + defaultLabelValueBase + strconv.Itoa(int(now.Unix())),
 	})

--- a/cmd/deployment-check/main.go
+++ b/cmd/deployment-check/main.go
@@ -178,7 +178,7 @@ func main() {
 	log.Infoln("Kubernetes client created.")
 
 	// Start listening to interrupts.
-	go listenForInterrupts(ctx)
+	go listenForInterrupts(ctx, ctxCancel)
 
 	// Catch panics.
 	var r interface{}
@@ -191,11 +191,11 @@ func main() {
 	}()
 
 	// Start deployment check.
-	runDeploymentCheck()
+	runDeploymentCheck(ctx)
 }
 
 // listenForInterrupts watches the signal and done channels for termination.
-func listenForInterrupts(ctx context.Context) {
+func listenForInterrupts(ctx context.Context, cancel context.CancelFunc) {
 
 	// Relay incoming OS interrupt signals to the signalChan.
 	signal.Notify(signalChan, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGINT)
@@ -204,7 +204,7 @@ func listenForInterrupts(ctx context.Context) {
 	log.Debugln("Signal received was:", sig.String())
 
 	log.Debugln("Cancelling context.")
-	ctxCancel() // Causes all functions within the check to return without error and abort. NOT an error
+	cancel() // Causes all functions within the check to return without error and abort. NOT an error
 	// condition; this is a response to an external shutdown signal.
 
 	// Clean up pods here.

--- a/cmd/deployment-check/run_check.go
+++ b/cmd/deployment-check/run_check.go
@@ -24,7 +24,7 @@ import (
 // runDeploymentCheck sets up a deployment and applies it to the cluster.
 // Sets up a deployment and service and uses the client to deploy the test deployment and service.
 // Attempts to hit the service hostname endpoint, looking for a 200 and reports a success if able to retrieve a 200.
-func runDeploymentCheck() {
+func runDeploymentCheck(ctx context.Context) {
 
 	log.Infoln("Waiting for node to become ready before starting check.")
 	waitForNodeToJoin(ctx)
@@ -66,7 +66,7 @@ func runDeploymentCheck() {
 	// Apply the deployment struct manifest to the cluster.
 	var deploymentResult DeploymentResult
 	select {
-	case deploymentResult = <-createDeployment(deploymentConfig):
+	case deploymentResult = <-createDeployment(ctx, deploymentConfig):
 		// Handle errors when the deployment creation process completes.
 		if deploymentResult.Err != nil {
 			log.Errorln("error occurred creating deployment in cluster:", deploymentResult.Err)
@@ -141,7 +141,7 @@ func runDeploymentCheck() {
 	// Utilize a backoff loop for the request, the hostname needs to be allotted enough time
 	// for the hostname to resolve and come up.
 	select {
-	case err := <-makeRequestToDeploymentCheckService(ipAddress):
+	case err := <-makeRequestToDeploymentCheckService(ctx, ipAddress):
 		if err != nil {
 			// Handle errors when the HTTP request process completes.
 			log.Errorln("error occurred making request to service in cluster:", err)
@@ -179,7 +179,7 @@ func runDeploymentCheck() {
 		// Apply the deployment struct manifest to the cluster.
 		var updateDeploymentResult DeploymentResult
 		select {
-		case updateDeploymentResult = <-updateDeployment(rolledUpdateConfig):
+		case updateDeploymentResult = <-updateDeployment(ctx, rolledUpdateConfig):
 			// Handle errors when the deployment creation process completes.
 			if updateDeploymentResult.Err != nil {
 				log.Errorln("error occurred applying rolling-update to deployment in cluster:", updateDeploymentResult.Err)
@@ -207,7 +207,7 @@ func runDeploymentCheck() {
 
 		// Hit the service again, looking for a 200.
 		select {
-		case err := <-makeRequestToDeploymentCheckService(ipAddress):
+		case err := <-makeRequestToDeploymentCheckService(ctx, ipAddress):
 			// Handle errors when the HTTP request process completes.
 			if err != nil {
 				log.Errorln("error occurred creating service in cluster:", err)
@@ -301,7 +301,7 @@ func cleanUpOrphanedResources(ctx context.Context) chan error {
 			log.Infoln("Found previous service.")
 		}
 
-		deploymentExists, err := findPreviousDeployment()
+		deploymentExists, err := findPreviousDeployment(ctx)
 		if err != nil {
 			log.Warnln("Failed to find previous deployment:", err.Error())
 		}

--- a/cmd/deployment-check/service_requester.go
+++ b/cmd/deployment-check/service_requester.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,7 +30,7 @@ type RequestResult struct {
 
 // makeRequestToDeploymentCheckService attempts to make an HTTP request to the service
 // hostname and returns a boolean value. Returns a chan of errors.
-func makeRequestToDeploymentCheckService(hostname string) chan error {
+func makeRequestToDeploymentCheckService(ctx context.Context, hostname string) chan error {
 
 	requestChan := make(chan error)
 


### PR DESCRIPTION
Part of https://github.com/Comcast/kuberhealthy/issues/640

Since the context is now propagated all the way down from the `main()`, I'm not sure if we really need package variables `ctx` and `ctxCancel`. Should I remove these package variables?