### PR TITLE
feat: allow users that install pod-status check via helm to optionally allow cluster wide scope

### DIFF
--- a/cmd/pod-status-check/README.md
+++ b/cmd/pod-status-check/README.md
@@ -45,10 +45,32 @@ Note: This check assumes that a pod is unhealthy if it is over 10 minutes old an
 - Failed:  All Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.
 - Unknown:  For some reason the state of the Pod could not be obtained, typically due to an error in communicating with the host of the Pod.
 
+#### Options
+
+By default, `Pod Status Check` will check pods in the same namespace it is installed into.  This means the RBAC requirements for the service account the check runs with can be limited to a single namespace scope.
+
+It is possible to configure `Pod Status Check` to check pods from all namespaces in a cluster, this requires cluster wide permissions for the service account and is not recommended for multi-tenant setups.
 
 #### How-to
+
+##### kubectl apply
 To implement the Pod Status Check with Kuberhealthy, apply the configuration file [pod-status-check.yaml](pod-status-check.yaml)
 
 `kubectl apply -f https://raw.githubusercontent.com/Comcast/kuberhealthy/2.0.0/cmd/pod-status-check/pod-status-check.yaml`
 
 to your Kubernetes Cluster.  Make sure that you are using the latest release of Kuberhealthy 2.0.0.
+
+If you want to enable the cluster wide option described above then __instead__ apply with cluster permissions [pod-status-check-clusterscope.yaml](pod-status-check-clusterscope.yaml).
+
+##### Helm
+
+```
+helm repo add kuberhealthy https://comcast.github.io/kuberhealthy/helm-repos
+
+helm install kuberhealthy kuberhealthy/kuberhealthy --set check.podStatus.enabled=true
+```
+
+To enable cluster wide check with cluster permissions
+```
+helm install kuberhealthy kuberhealthy/kuberhealthy --set check.podStatus.enabled=true --set check.podStatus.cluster.enabled=true
+```

--- a/cmd/pod-status-check/README.md
+++ b/cmd/pod-status-check/README.md
@@ -72,5 +72,5 @@ helm install kuberhealthy kuberhealthy/kuberhealthy --set check.podStatus.enable
 
 To enable cluster wide check with cluster permissions
 ```
-helm install kuberhealthy kuberhealthy/kuberhealthy --set check.podStatus.enabled=true --set check.podStatus.cluster.enabled=true
+helm install kuberhealthy kuberhealthy/kuberhealthy --set check.podStatus.enabled=true --set check.podStatus.allNamespaces=true
 ```

--- a/cmd/pod-status-check/main.go
+++ b/cmd/pod-status-check/main.go
@@ -26,19 +26,23 @@ var namespace string
 var skipDurationEnv string
 
 func init() {
-	skipDurationEnv = os.Getenv("SKIP_DURATION")
-	namespace = os.Getenv("TARGET_NAMESPACE")
 	checkclient.Debug = true
 }
 
+type Options struct {
+	client kubernetes.Interface
+}
+
 func main() {
-	client, err := kubeClient.Create(KubeConfigFile)
+	var err error
+	o := Options{}
+	o.client, err = kubeClient.Create(KubeConfigFile)
 	if err != nil {
 		log.Fatalln("Unable to create kubernetes client", err)
 	}
 
 	// get our list of failed pods, if there are any errors, report failures to Kuberhealthy servers.
-	failures, err := findPodsNotRunning(client)
+	failures, err := o.findPodsNotRunning()
 	if err != nil {
 		err = checkclient.ReportFailure([]string{err.Error()})
 		if err != nil {
@@ -67,11 +71,21 @@ func main() {
 }
 
 // finds pods that are older than 10 minutes and are in an unhealthy lifecycle phase
-func findPodsNotRunning(client *kubernetes.Clientset) ([]string, error) {
+func (o Options) findPodsNotRunning() ([]string, error) {
 
 	var failures []string
 
-	pods, err := client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app!=kuberhealthy-check,source!=kuberhealthy"})
+	skipDurationEnv = os.Getenv("SKIP_DURATION")
+	namespace = os.Getenv("TARGET_NAMESPACE")
+	if namespace == "" {
+		log.Println("looking for pods across all namespaces, this requires a cluster role")
+		// it is the same value but we are being explicit that we are listing pods in all namespaces
+		namespace = v1.NamespaceAll
+	} else {
+		log.Printf("looking for pods in namespace %s", namespace)
+	}
+
+	pods, err := o.client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app!=kuberhealthy-check,source!=kuberhealthy"})
 	if err != nil {
 		return failures, err
 	}

--- a/cmd/pod-status-check/main_test.go
+++ b/cmd/pod-status-check/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_findPodsNotRunning(t *testing.T) {
+	objects := getTestPods()
+	os.Setenv("SKIP_DURATION", "10m")
+
+	type fields struct {
+		objects   []runtime.Object
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []string
+		wantErr bool
+	}{
+		{name: "single_namespace", fields: fields{
+			namespace: "foo",
+		}, want: []string{"foo-pod is in pod status phase Pending "}, wantErr: false},
+		{name: "multi_namespace", fields: fields{
+			namespace: "",
+		}, want: []string{"bar-pod is in pod status phase Pending ", "foo-pod is in pod status phase Pending "}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			os.Setenv("TARGET_NAMESPACE", tt.fields.namespace)
+
+			client := fake.NewSimpleClientset(objects...)
+			o := Options{
+				client: client,
+			}
+			got, err := o.findPodsNotRunning()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findErrors() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findErrors() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
+func getTestPods() []runtime.Object {
+
+	return []runtime.Object{
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-pod",
+				Namespace: "foo",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodPending,
+			},
+		},
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar-pod",
+				Namespace: "bar",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodPending,
+			},
+		},
+	}
+}

--- a/cmd/pod-status-check/pod-status-check-clusterscope.yaml
+++ b/cmd/pod-status-check/pod-status-check-clusterscope.yaml
@@ -1,0 +1,66 @@
+---
+# Source: kuberhealthy/templates/khcheck-pod-status.yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: pod-status
+  namespace: kuberhealthy
+spec:
+  runInterval: 5m
+  timeout: 15m
+  podSpec:
+    securityContext:
+      runAsUser: 999
+      fsGroup: 999
+    containers:
+      - env:
+          - name: SKIP_DURATION
+            value: "10m"
+        image: kuberhealthy/pod-status-check:v1.2.2
+        imagePullPolicy: IfNotPresent
+        name: main
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+    serviceAccountName: pod-status-sa
+---
+# Source: kuberhealthy/templates/khcheck-pod-status.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-status-check-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-status-role
+subjects:
+  - kind: ServiceAccount
+    name: pod-status-sa
+    namespace: kuberhealthy
+---
+# Source: kuberhealthy/templates/khcheck-pod-status.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-status-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: kuberhealthy/templates/khcheck-pod-status.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-status-sa
+  namespace: kuberhealthy

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -50,20 +50,20 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: jx-pod-status-check-rb
+  name: pod-status-check-rb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: jx-pod-status-role
+  name: pod-status-role
 subjects:
   - kind: ServiceAccount
-    name: jx-pod-status-sa
+    name: pod-status-sa
     namespace: kuberhealthy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: jx-pod-status-role
+  name: pod-status-role
 rules:
   - apiGroups:
       - ""

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -46,7 +46,7 @@ spec:
     {{- end }}
     serviceAccountName: pod-status-sa
 ---
-{{- if .Values.check.podStatus.cluster.enabled }}
+{{- if .Values.check.podStatus.cluster.allNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -75,7 +75,7 @@ rules:
       - list
       - watch
 {{- end }}
-{{- if not .Values.check.podStatus.cluster.enabled }}
+{{- if not .Values.check.podStatus.allNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -111,7 +111,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pod-status-sa
-{{- if .Values.check.podStatus.cluster.enabled }}
+{{- if .Values.check.podStatus.allNamespaces }}
   namespace: kuberhealthy
 {{- else }}
   namespace: {{ .Release.Namespace }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -17,10 +17,12 @@ spec:
       - env:
           - name: SKIP_DURATION
             value: "10m"
+          {{- if not .Values.check.podStatus.cluster.enabled }}
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- end }}
 {{- range $key, $value := .Values.check.podStatus.extraEnvs }}
           - name: {{ $key }}
             value: {{ $value | quote }}
@@ -43,6 +45,37 @@ spec:
 {{- toYaml .Values.check.podStatus.nodeSelector | nindent 6 }}
     {{- end }}
     serviceAccountName: pod-status-sa
+---
+{{- if .Values.check.podStatus.cluster.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jx-pod-status-check-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jx-pod-status-role
+subjects:
+  - kind: ServiceAccount
+    name: jx-pod-status-sa
+    namespace: kuberhealthy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jx-pod-status-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}
+{{- if not .Values.check.podStatus.cluster.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -72,10 +105,15 @@ rules:
       - get
       - list
       - watch
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pod-status-sa
+{{- if .Values.check.podStatus.cluster.enabled }}
+  namespace: kuberhealthy
+{{- else }}
   namespace: {{ .Release.Namespace }}
+{{- end}}
 {{- end}}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -17,7 +17,7 @@ spec:
       - env:
           - name: SKIP_DURATION
             value: "10m"
-          {{- if not .Values.check.podStatus.cluster.enabled }}
+          {{- if not .Values.check.podStatus.allNamespaces }}
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -46,7 +46,7 @@ spec:
     {{- end }}
     serviceAccountName: pod-status-sa
 ---
-{{- if .Values.check.podStatus.cluster.allNamespaces }}
+{{- if .Values.check.podStatus.allNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -138,6 +138,8 @@ check:
       tag: v1.2.2
     extraEnvs:
     nodeSelector: {}
+    cluster:
+      enabled: false
   networkConnection:
     enabled: false
     runInterval: 30m

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -138,8 +138,7 @@ check:
       tag: v1.2.2
     extraEnvs:
     nodeSelector: {}
-    cluster:
-      enabled: false
+    allNamespaces: true
   networkConnection:
     enabled: false
     runInterval: 30m

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -138,7 +138,7 @@ check:
       tag: v1.2.2
     extraEnvs:
     nodeSelector: {}
-    allNamespaces: true
+    allNamespaces: false
   networkConnection:
     enabled: false
     runInterval: 30m


### PR DESCRIPTION
related discussion https://github.com/Comcast/kuberhealthy/issues/680

This change also adds a unit test using kubernetes fake client so I needed to change the findPodsNotRunning funtion args, happy to put back and remove the test if prefferred though