### PR TITLE
Adds CPU and memory request parameters to check-reaper cronjob

### DIFF
--- a/cmd/check-reaper/check-reaper.yaml
+++ b/cmd/check-reaper/check-reaper.yaml
@@ -10,9 +10,13 @@ spec:
       template:
         spec:
           containers:
-            - name: check-reaper
-              image: kuberhealthy/check-reaper:v1.5.0
+            - image: kuberhealthy/check-reaper:v1.5.0
               imagePullPolicy: IfNotPresent
+              name: check-reaper
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 50Mi
               env:
                 - name: SINGLE_NAMESPACE
                   value: kuberhealthy


### PR DESCRIPTION
Jobs will fail to schedule on some clusters if CPU and memory requests are not explicitly set in spec.