### PR TITLE
Deployment check taint

### DIFF
--- a/.ci/values.yaml
+++ b/.ci/values.yaml
@@ -75,8 +75,6 @@ check:
     extraEnvs:
       CHECK_DEPLOYMENT_REPLICAS: "4"
       CHECK_DEPLOYMENT_ROLLING_UPDATE: "true"
-      TOLERATION_VALUE: ""
-      NODE_SELECTOR: ""
       DEBUG: "true"
     nodeSelector: {}
   dnsInternal:

--- a/.ci/values.yaml
+++ b/.ci/values.yaml
@@ -71,10 +71,12 @@ check:
     timeout: 15m
     image:
       repository: kuberhealthy/deployment-check
-      tag: v1.6.2
+      tag: v1.7.0
     extraEnvs:
       CHECK_DEPLOYMENT_REPLICAS: "4"
       CHECK_DEPLOYMENT_ROLLING_UPDATE: "true"
+      TOLERATION_VALUE: ""
+      NODE_SELECTOR: ""
       DEBUG: "true"
     nodeSelector: {}
   dnsInternal:

--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 IMAGE="kuberhealthy/deployment-check"
-TAG="v1.6.2"
+TAG="v1.7.2"
 
 build:
 	docker build -t ${IMAGE}:${TAG} -f Dockerfile ../../

--- a/cmd/deployment-check/Makefile
+++ b/cmd/deployment-check/Makefile
@@ -1,5 +1,5 @@
 IMAGE="kuberhealthy/deployment-check"
-TAG="v1.7.2"
+TAG="v1.7.0"
 
 build:
 	docker build -t ${IMAGE}:${TAG} -f Dockerfile ../../

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -82,9 +82,9 @@ spec:
           - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
             value: "true"
           - name: TOLERATION_VALUE
-            value: "dedicated"
+            value: ""
           - name: NODE_SELECTOR
-            value: "dedicated=kuberhealthy"
+            value: ""
         resources:
           requests:
             cpu: 25m

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -53,6 +53,10 @@ This check follows the list of actions in order during the run of the check:
 - `ADDITIONAL_ENV_VARS`: Comma separated list of `key=value` variables passed into the pod's containers.
 - `SHUTDOWN_GRACE_PERIOD`: Amount of time in seconds the shutdown will allow itself to clean up after an interrupt signal (default=`30s`).
 - `DEBUG`: Verbose debug logging.
+- `TOLERATION_VALUE`: Key to be set for toleration in the event dedicated nodes are required for scheduling.
+  (default= "")
+- `NODE_SELECTOR`: node selector label to be passed in to range for when scheduling on dedicated node.
+  (default= "")
 
 #### Example KuberhealthyCheck Spec
 

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -74,7 +74,7 @@ spec:
   podSpec:
     containers:
       - name: deployment
-        image: kuberhealthy/deployment-check:v1.7.2
+        image: kuberhealthy/deployment-check:v1.7.0
         imagePullPolicy: Always
         env:
           - name: CHECK_DEPLOYMENT_REPLICAS

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -8,7 +8,7 @@ Custom images can be used for this check and can be specified with the `CHECK_IM
 
 The number of replicas the `deployment` brings up can be adjusted with the `CHECK_DEPLOYMENT_REPLICAS` environment variable. By default the amount of replicas used is `2`, but this can be customized for different scenarios and environments. `maxSurge` and `maxUnavailable` values for the deployment is calculated to be %50 of the deployment replicas (rounded-up).
 
-A successful run implies that a deployment and service can be brought up and the corresponding hostname endpoint returns a `200 OK` response.  A failure implies that an error occurred anywhere in the deployment creation, service creation, HTTP request, or tear down process -- resulting in an error report to the _Kuberhealthy_ status page.
+A successful run implies that a deployment and service can be brought up and the corresponding hostname endpoint returns a `200 OK` response. A failure implies that an error occurred anywhere in the deployment creation, service creation, HTTP request, or tear down process -- resulting in an error report to the _Kuberhealthy_ status page.
 
 #### Deployment Check Diagram
 
@@ -17,12 +17,13 @@ A successful run implies that a deployment and service can be brought up and the
 #### Check Steps
 
 This check follows the list of actions in order during the run of the check:
+
 1.  Looks for old services and deployments belonging to this check and cleans them up.
 2.  Creates a deployment configuration, applies it to the namespace, and waits for the deployment to come up.
 3.  Creates a service configuration, applies it to the namespace, and waits for the service to come up.
 4.  Makes an HTTP Get request to the service endpoint, looking for a `200 OK`.
 
-__IF ROLLING-UPDATE OPTION IS ENABLED__
+**IF ROLLING-UPDATE OPTION IS ENABLED**
 
 5.  Creates an updated deployment configuration, applies it to the namespace, and waits for the deployment to complete its rolling-update.
 6.  Makes a second HTTP Get request to the service endpoint, looking for another `200 OK`.
@@ -35,22 +36,23 @@ __IF ROLLING-UPDATE OPTION IS ENABLED__
 - Check name: `deployment`
 
 #### Check Configuration Environment Variables
-  - `CHECK_IMAGE`: Initial container image. (default=`nginxinc/nginx-unprivileged:1.17.8`)
-  - `CHECK_IMAGE_ROLL_TO`: Container image to roll to. (default=`nginxinc/nginx-unprivileged:1.17.9`)
-  - `CHECK_DEPLOYMENT_NAME`: Name for the check's deployment. (default=`deployment-deployment`)
-  - `CHECK_SERVICE_NAME`: Name for the check's service. (default=`deployment-svc`)
-  - `CHECK_NAMESPACE`: Namespace for the check (default=`kuberhealthy`).
-  - `CHECK_DEPLOYMENT_REPLICAS`: Number of replicas in the deployment (default=`2`).
-  - `CHECK_DEPLOYMENT_ROLLING_UPDATE`: Boolean to enable rolling-update (default=`false`).
-  - `CHECK_CONTAINER_PORT`: Check pod container port (default=`8080`).
-  - `CHECK_POD_CPU_REQUEST`: Check pod deployment CPU request value. Calculated in decimal SI units `(15 = 15m cpu)`.
-  - `CHECK_POD_CPU_LIMIT`: Check pod deployment CPU limit value. Calculated in decimal SI units `(75 = 75m cpu)`.
-  - `CHECK_POD_MEM_REQUEST`: Check pod deployment memory request value. Calculated in binary SI units `(20 * 1024^2 = 20Mi memory)`.
-  - `CHECK_POD_MEM_LIMIT`: Check pod deployment memory limit value. Calculated in binary SI units `(75 * 1024^2 = 75Mi memory)`.
-  - `NODE_SELECTOR`: Comma separated list of `key=value` node selector values for the deployment check. By default, there are no selectors.
-  - `ADDITIONAL_ENV_VARS`: Comma separated list of `key=value` variables passed into the pod's containers.
-  - `SHUTDOWN_GRACE_PERIOD`: Amount of time in seconds the shutdown will allow itself to clean up after an interrupt signal (default=`30s`).
-  - `DEBUG`: Verbose debug logging.
+
+- `CHECK_IMAGE`: Initial container image. (default=`nginxinc/nginx-unprivileged:1.17.8`)
+- `CHECK_IMAGE_ROLL_TO`: Container image to roll to. (default=`nginxinc/nginx-unprivileged:1.17.9`)
+- `CHECK_DEPLOYMENT_NAME`: Name for the check's deployment. (default=`deployment-deployment`)
+- `CHECK_SERVICE_NAME`: Name for the check's service. (default=`deployment-svc`)
+- `CHECK_NAMESPACE`: Namespace for the check (default=`kuberhealthy`).
+- `CHECK_DEPLOYMENT_REPLICAS`: Number of replicas in the deployment (default=`2`).
+- `CHECK_DEPLOYMENT_ROLLING_UPDATE`: Boolean to enable rolling-update (default=`false`).
+- `CHECK_CONTAINER_PORT`: Check pod container port (default=`8080`).
+- `CHECK_POD_CPU_REQUEST`: Check pod deployment CPU request value. Calculated in decimal SI units `(15 = 15m cpu)`.
+- `CHECK_POD_CPU_LIMIT`: Check pod deployment CPU limit value. Calculated in decimal SI units `(75 = 75m cpu)`.
+- `CHECK_POD_MEM_REQUEST`: Check pod deployment memory request value. Calculated in binary SI units `(20 * 1024^2 = 20Mi memory)`.
+- `CHECK_POD_MEM_LIMIT`: Check pod deployment memory limit value. Calculated in binary SI units `(75 * 1024^2 = 75Mi memory)`.
+- `NODE_SELECTOR`: Comma separated list of `key=value` node selector values for the deployment check. By default, there are no selectors.
+- `ADDITIONAL_ENV_VARS`: Comma separated list of `key=value` variables passed into the pod's containers.
+- `SHUTDOWN_GRACE_PERIOD`: Amount of time in seconds the shutdown will allow itself to clean up after an interrupt signal (default=`30s`).
+- `DEBUG`: Verbose debug logging.
 
 #### Example KuberhealthyCheck Spec
 
@@ -67,29 +69,27 @@ spec:
   timeout: 15m
   podSpec:
     containers:
-    - name: deployment
-      image: kuberhealthy/deployment-check:v1.6.2
-      imagePullPolicy: IfNotPresent
-      env:
-        - name: CHECK_IMAGE
-          value: "nginx:1.17-perl"
-        - name: CHECK_IMAGE_ROLL_TO
-          value: "nginx:1.17.5-perl"
-        - name: CHECK_DEPLOYMENT_REPLICAS
-          value: "4"
-        - name: CHECK_CONTAINER_PORT
-          value: "80"
-        - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
-          value: "true"
-        - name: ADDITIONAL_ENV_VARS
-          value: "var1=foo,var2=bar"
-      resources:
-        requests:
-          cpu: 15m
-          memory: 15Mi
-        limits:
-          cpu: 25m
-      restartPolicy: Always
+      - name: deployment
+        image: kuberhealthy/deployment-check:v1.7.2
+        imagePullPolicy: Always
+        env:
+          - name: CHECK_DEPLOYMENT_REPLICAS
+            value: "4"
+          - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
+            value: "true"
+          - name: TOLERATION_VALUE
+            value: "dedicated"
+          - name: NODE_SELECTOR
+            value: "dedicated=kuberhealthy"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 15Mi
+          limits:
+            cpu: 40m
+        restartPolicy: Never
+    serviceAccountName: deployment-sa
+    terminationGracePeriodSeconds: 60
 ```
 
 The following configuration will create a deployment with 6 replicas and roll from `nginxinc/nginx-unprivileged:1.17.8` to `nginxinc/nginx-unprivileged:1.17.9`:
@@ -105,32 +105,33 @@ spec:
   timeout: 15m
   podSpec:
     containers:
-    - name: deployment
-      image: kuberhealthy/deployment-check:v1.6.2
-      imagePullPolicy: IfNotPresent
-      env:
-        - name: CHECK_DEPLOYMENT_REPLICAS
-          value: "6"
-        - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
-          value: "true"
-      resources:
-        requests:
-          cpu: 15m
-          memory: 15Mi
-        limits:
-          cpu: 25m
-      restartPolicy: Always
+      - name: deployment
+        image: kuberhealthy/deployment-check:v1.6.2
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: CHECK_DEPLOYMENT_REPLICAS
+            value: "6"
+          - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
+            value: "true"
+        resources:
+          requests:
+            cpu: 15m
+            memory: 15Mi
+          limits:
+            cpu: 25m
+        restartPolicy: Always
 ```
 
 #### Install
 
-To use the *Deployment Check* with Kuberhealthy, apply the configuration file [deployment-check.yaml](deployment-check.yaml) to your Kubernetes Cluster. The following command will also apply the configuration file to your current context:
+To use the _Deployment Check_ with Kuberhealthy, apply the configuration file [deployment-check.yaml](deployment-check.yaml) to your Kubernetes Cluster. The following command will also apply the configuration file to your current context:
 
 `kubectl apply -f https://raw.githubusercontent.com/Comcast/kuberhealthy/2.0.0/cmd/deployment-check/deployment-check.yaml`
 
 Make sure you are using the latest release of Kuberhealthy 2.0.0 or later.
 
 The check configuration file contains:
+
 - KuberhealthyCheck
 - Role
 - Rolebinding

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -10,7 +10,7 @@ spec:
   podSpec:
     containers:
     - name: deployment
-      image: kuberhealthy/deployment-check:v1.7.2
+      image: kuberhealthy/deployment-check:v1.7.0
       imagePullPolicy: IfNotPresent
       env:
         - name: CHECK_DEPLOYMENT_REPLICAS

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -17,6 +17,8 @@ spec:
           value: "4"
         - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
           value: "true"
+        - name: TOLERATION_VALUE
+          value: "deploymentCheck"
       resources:
         requests:
           cpu: 25m

--- a/cmd/deployment-check/deployment-check.yaml
+++ b/cmd/deployment-check/deployment-check.yaml
@@ -10,7 +10,7 @@ spec:
   podSpec:
     containers:
     - name: deployment
-      image: kuberhealthy/deployment-check:v1.6.2
+      image: kuberhealthy/deployment-check:v1.7.2
       imagePullPolicy: IfNotPresent
       env:
         - name: CHECK_DEPLOYMENT_REPLICAS
@@ -18,7 +18,9 @@ spec:
         - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
           value: "true"
         - name: TOLERATION_VALUE
-          value: "deploymentCheck"
+          value: "dedicated"
+        - name: NODE_SELECTOR
+          value: "dedicated=kuberhealthy"
       resources:
         requests:
           cpu: 25m

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -267,14 +267,19 @@ func createDeployment(ctx context.Context, deploymentConfig *v1.Deployment) chan
 // createContainerConfig creates a container resource spec and returns it.
 func createToleration(t string) corev1.Toleration {
 
+	// return blank tolerations if no value provided in yaml file
+	if len(t) == 0 {
+		tolerations := corev1.Toleration{}
+		return tolerations
+	}
+
 	// Create toleration Key
 	tolerations := corev1.Toleration{
 		Key:      t,
-		Operator: "Equals",
+		Operator: "Equal",
 		Value:    "kuberhealthy",
 		Effect:   "NoSchedule",
 	}
-
 	return tolerations
 }
 

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -270,7 +270,8 @@ func createToleration(t string) corev1.Toleration {
 	// Create toleration Key
 	tolerations := corev1.Toleration{
 		Key:      t,
-		Operator: "Exists",
+		Operator: "Equals",
+		Value:    "kuberhealthy",
 		Effect:   "NoSchedule",
 	}
 

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -269,7 +269,8 @@ func createToleration(t string) corev1.Toleration {
 
 	// Create toleration Key
 	tolerations := corev1.Toleration{
-		Key: t,
+		Key:      t,
+		Operator: "Exists",
 	}
 
 	return tolerations

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +30,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	watchpkg "k8s.io/apimachinery/pkg/watch"
+)
+
+var (
+	// Toleration value to be set in deployment pod
+	tolerationValue = os.Getenv("TOLERATION_VALUE")
 )
 
 const (
@@ -86,7 +92,7 @@ func createDeploymentConfig(image string) *v1.Deployment {
 
 	//
 	var toleration corev1.Toleration
-	toleration = createToleration("deploymentCheck")
+	toleration = createToleration(tolerationValue)
 	tolerations = append(tolerations, toleration)
 
 	// Check for given node selector values.

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -269,7 +269,12 @@ func createToleration(t string) corev1.Toleration {
 
 	// return blank tolerations if no value provided in yaml file
 	if len(t) == 0 {
-		tolerations := corev1.Toleration{}
+		tolerations := corev1.Toleration{
+			Key:      "",
+			Operator: "Exists",
+			Value:    "",
+			Effect:   "",
+		}
 		return tolerations
 	}
 

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -271,6 +271,7 @@ func createToleration(t string) corev1.Toleration {
 	tolerations := corev1.Toleration{
 		Key:      t,
 		Operator: "Exists",
+		Effect:   "NoSchedule",
 	}
 
 	return tolerations

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -30,11 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	watchpkg "k8s.io/apimachinery/pkg/watch"
-)
-
-var (
-	// Toleration value to be set in deployment pod
-	tolerationValue = os.Getenv("TOLERATION_VALUE")
 )
 
 const (
@@ -264,16 +258,13 @@ func createDeployment(ctx context.Context, deploymentConfig *v1.Deployment) chan
 	return createChan
 }
 
-// createContainerConfig creates a container resource spec and returns it.
+// createToleration creates a container resource spec and returns it.
 func createToleration(t string) corev1.Toleration {
 
 	// return blank tolerations if no value provided in yaml file
 	if len(t) == 0 {
 		tolerations := corev1.Toleration{
-			Key:      "",
-			Operator: "Exists",
-			Value:    "",
-			Effect:   "",
+			Operator: corev1.TolerationOpExists,
 		}
 		return tolerations
 	}
@@ -281,9 +272,9 @@ func createToleration(t string) corev1.Toleration {
 	// Create toleration Key
 	tolerations := corev1.Toleration{
 		Key:      t,
-		Operator: "Equal",
+		Operator: corev1.TolerationOpEqual,
 		Value:    "kuberhealthy",
-		Effect:   "NoSchedule",
+		Effect:   corev1.TaintEffectNoSchedule,
 	}
 	return tolerations
 }

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -71,6 +71,7 @@ func createDeploymentConfig(image string) *v1.Deployment {
 
 	// Make a slice for containers for the pods in the deployment.
 	containers := make([]corev1.Container, 0)
+	tolerations := make([]corev1.Toleration, 0)
 
 	if len(checkImage) == 0 {
 		err := errors.New("check image url for container is empty: " + checkImage)
@@ -82,6 +83,11 @@ func createDeploymentConfig(image string) *v1.Deployment {
 	var container corev1.Container
 	container = createContainerConfig(checkImage)
 	containers = append(containers, container)
+
+	//
+	var toleration corev1.Toleration
+	toleration = createToleration("deploymentCheck")
+	tolerations = append(tolerations, toleration)
 
 	// Check for given node selector values.
 	// Set the map to the default of nil (<none>) if there are no selectors given.
@@ -98,6 +104,7 @@ func createDeploymentConfig(image string) *v1.Deployment {
 		RestartPolicy:                 corev1.RestartPolicyAlways,
 		TerminationGracePeriodSeconds: &graceSeconds,
 		ServiceAccountName:            checkServiceAccount,
+		Tolerations:                   tolerations,
 	}
 
 	// Make labels for pod and deployment.
@@ -249,6 +256,17 @@ func createDeployment(ctx context.Context, deploymentConfig *v1.Deployment) chan
 	}()
 
 	return createChan
+}
+
+// createContainerConfig creates a container resource spec and returns it.
+func createToleration(t string) corev1.Toleration {
+
+	// Create toleration Key
+	tolerations := corev1.Toleration{
+		Key: t,
+	}
+
+	return tolerations
 }
 
 // createContainerConfig creates a container resource spec and returns it.

--- a/cmd/deployment-check/main.go
+++ b/cmd/deployment-check/main.go
@@ -66,6 +66,9 @@ var (
 	checkDeploymentNodeSelectorsEnv = os.Getenv("NODE_SELECTOR")
 	checkDeploymentNodeSelectors    = make(map[string]string)
 
+	// Toleration value to be set in deployment pod
+	tolerationValue = os.Getenv("TOLERATION_VALUE")
+
 	// ServiceAccount that will deploy the test deployment [default = default]
 	checkServiceAccountEnv = os.Getenv("CHECK_SERVICE_ACCOUNT")
 	checkServiceAccount    string


### PR DESCRIPTION
Included env variables and a new function to allow the ability to schedule the checker pods on dedicated nodes. Also modified the code to still take in blank values for those env variables to schedule anywhere as it does today. This has been tested in lab for both dedicated nodes as well as blank values which successfully schedules correctly for both circumstances.