### PR TITLE
Fix #736 replace legacy source url

### DIFF
--- a/deploy/helm/kuberhealthy/Chart.yaml
+++ b/deploy/helm/kuberhealthy/Chart.yaml
@@ -28,5 +28,5 @@ keywords:
 - prometheus
 sources:
 - https://github.com/Comcast/kuberhealthy
-- https://github.com/helm/charts/tree/master/stable/kuberhealthy
+- https://github.com/Comcast/kuberhealthy/tree/master/deploy/helm/kuberhealthy
 icon: https://raw.githubusercontent.com/Comcast/kuberhealthy/master/images/logo-square.png


### PR DESCRIPTION
Replace the legacy "stable" helm repo source with the one from this repo.