### PR TITLE
fix: add helper method to create CheckClient

### DIFF
--- a/pkg/khcheckcrd/api.go
+++ b/pkg/khcheckcrd/api.go
@@ -65,3 +65,10 @@ func Client(GroupName string, GroupVersion string, kubeConfig string, namespace 
 	client, err := rest.RESTClientFor(&config)
 	return &KuberhealthyCheckClient{restClient: client}, err
 }
+
+// CreateClient returns a Kuberhealthy Check client using an existing rest client
+func CreateClient(client rest.Interface) *KuberhealthyCheckClient {
+	return &KuberhealthyCheckClient{
+		restClient: client,
+	}
+}

--- a/pkg/khstatecrd/api.go
+++ b/pkg/khstatecrd/api.go
@@ -62,7 +62,7 @@ func Client(GroupName string, GroupVersion string, kubeConfig string, namespace 
 	return &KuberhealthyStateClient{restClient: client}, err
 }
 
-// // CreateClient returns a Kuberhealthy State client using an existing rest client
+// CreateClient returns a Kuberhealthy State client using an existing rest client
 func CreateClient(client rest.Interface) *KuberhealthyStateClient {
 	return &KuberhealthyStateClient{
 		restClient: client,


### PR DESCRIPTION
so that we can create a CheckClient if we already have a rest.Interface instance for connecting to k8s clients

this is a similar method to the CreateClient we have in the khstatecrd package