### PR TITLE
Set default values for MaxPodsThreshold and JobDeleteTimeDuration

### DIFF
--- a/cmd/check-reaper/main.go
+++ b/cmd/check-reaper/main.go
@@ -70,7 +70,7 @@ func init() {
 	// Parse incoming jobDeleteTimeDurationEnv environment variable.
 	JobDeleteTimeDuration = JobDeleteTimeDurationDefault
 	if len(JobDeleteTimeDurationEnv) != 0 {
-		// convert JobDeleteMinutes into time.Duration
+		// convert JobDeleteTimeDurationEnv into time.Duration
 		JobDeleteTimeDuration, err = time.ParseDuration(JobDeleteTimeDurationEnv)
 		if err != nil {
 			log.Errorln("Error converting JOB_DELETE_TIME_DURATION to Duration. Using default value:", JobDeleteTimeDurationDefault)

--- a/cmd/check-reaper/main.go
+++ b/cmd/check-reaper/main.go
@@ -75,7 +75,7 @@ func init() {
 		if err != nil {
 			log.Errorln("Error converting JOB_DELETE_TIME_DURATION to Duration. Using default value:", JobDeleteTimeDurationDefault)
 		} else {
-			log.Infoln("Parsed MAX_PODS_THRESHOLD:", MaxPodsThreshold)
+			log.Infoln("Parsed JOB_DELETE_TIME_DURATION:", MaxPodsThreshold)
 		}
 	}
 }


### PR DESCRIPTION
In https://github.com/Comcast/kuberhealthy/pull/692, 2 new environment variables were added for check-reaper: `MAX_PODS_THRESHOLD` and `JOB_DELETE_TIME_DURATION`. If any of these environment variables are unset, then we'll get errors like:
```
level=error msg="Error converting MaxPodsThreshold to int"
```
or
```
time="2020-12-16T13:51:14Z" level=error msg="Error converting JobDeleteTimeDurationEnv to Float"
time="2020-12-16T13:51:14Z" level=error msg="Failed to reap khjobs with error:  time: invalid duration "
```

This PR sets default values in case these environment variables are unset or their values cannot be parsed.