### PR TITLE
Allow overriding resources for checks for #760

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -40,8 +40,17 @@ spec:
         name: main
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .Values.check.daemonset.resources.requests.cpu }}
+            memory: {{ .Values.check.daemonset.resources.requests.memory }}
+          {{- if .Values.check.daemonset.resources.limits }}
+          limits:
+            {{- if .Values.check.daemonset.resources.limits.cpu }}
+            cpu: {{ .Values.check.daemonset.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.check.daemonset.resources.limits.memory }}
+            memory: {{ .Values.check.daemonset.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -105,6 +105,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi    
   deployment:
     enabled: true
     runInterval: 10m


### PR DESCRIPTION
This is example for allowing resources to be set from values.yaml for daemonset check. If this sounds a good idea, I will update it for all checks in the repo! Please review and let me know!
Will help resolve - https://github.com/Comcast/kuberhealthy/issues/760