### PR TITLE
Allow overriding resources for checks #760

### DIFF
--- a/deploy/helm/kuberhealthy/templates/check-reaper.yaml
+++ b/deploy/helm/kuberhealthy/templates/check-reaper.yaml
@@ -23,8 +23,17 @@ spec:
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
-                  cpu: 10m
-                  memory: 50Mi
+                  cpu: {{ .Values.checkReaper.resources.requests.cpu }}
+                  memory: {{ .Values.checkReaper.resources.requests.memory }}
+                {{- if .Values.checkReaper.resources.limits }}
+                limits:
+                  {{- if .Values.checkReaper.resources.limits.cpu }}
+                  cpu: {{ .Values.checkReaper.resources.limits.cpu }}
+                  {{- end }}
+                  {{- if .Values.checkReaper.resources.limits.memory }}
+                  memory: {{ .Values.checkReaper.resources.limits.memory }}
+                  {{- end }}
+                {{- end }}
               env:
                 - name: SINGLE_NAMESPACE
                   value: ""

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -40,8 +40,17 @@ spec:
         name: main
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .Values.check.daemonset.resources.requests.cpu }}
+            memory: {{ .Values.check.daemonset.resources.requests.memory }}
+          {{- if .Values.check.daemonset.resources.limits }}
+          limits:
+            {{- if .Values.check.daemonset.resources.limits.cpu }}
+            cpu: {{ .Values.check.daemonset.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.check.daemonset.resources.limits.memory }}
+            memory: {{ .Values.check.daemonset.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -31,10 +31,17 @@ spec:
 {{- end }}
       resources:
         requests:
-          cpu: 25m
-          memory: 15Mi
+          cpu: {{ .Values.check.deployment.resources.requests.cpu }}
+          memory: {{ .Values.check.deployment.resources.requests.memory }}
+        {{- if .Values.check.deployment.resources.limits }}
         limits:
-          cpu: 40m
+          {{- if .Values.check.deployment.resources.limits.cpu }}
+          cpu: {{ .Values.check.deployment.resources.limits.cpu }}
+          {{- end }}
+          {{- if .Values.check.deployment.resources.limits.memory }}
+          memory: {{ .Values.check.deployment.resources.limits.memory }}
+          {{- end }}
+        {{- end }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -35,8 +35,17 @@ spec:
         name: main
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .Values.check.dnsExternal.resources.requests.cpu }}
+            memory: {{ .Values.check.dnsExternal.resources.requests.memory }}
+          {{- if .Values.check.dnsExternal.resources.limits }}
+          limits:
+            {{- if .Values.check.dnsExternal.resources.limits.cpu }}
+            cpu: {{ .Values.check.dnsExternal.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.check.dnsExternal.resources.limits.memory }}
+            memory: {{ .Values.check.dnsExternal.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -35,8 +35,17 @@ spec:
         name: main
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .Values.check.dnsInternal.resources.requests.cpu }}
+            memory: {{ .Values.check.dnsInternal.resources.requests.memory }}
+          {{- if .Values.check.dnsInternal.resources.limits }}
+          limits:
+            {{- if .Values.check.dnsInternal.resources.limits.cpu }}
+            cpu: {{ .Values.check.dnsInternal.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.check.dnsInternal.resources.limits.memory }}
+            memory: {{ .Values.check.dnsInternal.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -26,9 +26,7 @@ spec:
 {{- end }}
       resources:
         requests:
-          {{- if .Values.check.networkConnection.resources.requests.cpu }}
           cpu: {{ .Values.check.networkConnection.resources.requests.cpu }}
-          {{- end }}
           memory: {{ .Values.check.networkConnection.resources.requests.memory }}
         {{- if .Values.check.networkConnection.resources.limits }}
         limits:

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -26,7 +26,19 @@ spec:
 {{- end }}
       resources:
         requests:
-          memory: 5Mi
+          {{- if .Values.check.networkConnection.resources.requests.cpu }}
+          cpu: {{ .Values.check.networkConnection.resources.requests.cpu }}
+          {{- end }}
+          memory: {{ .Values.check.networkConnection.resources.requests.memory }}
+        {{- if .Values.check.networkConnection.resources.limits }}
+        limits:
+          {{- if .Values.check.networkConnection.resources.limits.cpu }}
+          cpu: {{ .Values.check.networkConnection.resources.limits.cpu }}
+          {{- end }}
+          {{- if .Values.check.networkConnection.resources.limits.memory }}
+          memory: {{ .Values.check.networkConnection.resources.limits.memory }}
+          {{- end }}
+        {{- end }}
       restartPolicy: Never
     {{- if .Values.check.networkConnection.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -34,8 +34,17 @@ spec:
         name: main
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .Values.check.podRestarts.resources.requests.cpu }}
+            memory: {{ .Values.check.podRestarts.resources.requests.memory }}
+          {{- if .Values.check.podRestarts.resources.limits }}
+          limits:
+            {{- if .Values.check.podRestarts.resources.limits.cpu }}
+            cpu: {{ .Values.check.podRestarts.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.check.podRestarts.resources.limits.memory }}
+            memory: {{ .Values.check.podRestarts.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -38,8 +38,17 @@ spec:
         name: main
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .Values.check.podStatus.resources.requests.cpu }}
+            memory: {{ .Values.check.podStatus.resources.requests.memory }}
+          {{- if .Values.check.podStatus.resources.limits }}
+          limits:
+            {{- if .Values.check.podStatus.resources.limits.cpu }}
+            cpu: {{ .Values.check.podStatus.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.check.podStatus.resources.limits.memory }}
+            memory: {{ .Values.check.podStatus.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -43,8 +43,17 @@ spec:
 {{- end }}
       resources:
         requests:
-          cpu: 10m
-          memory: 50Mi
+          cpu: {{ .Values.check.storage.resources.requests.cpu }}
+          memory: {{ .Values.check.storage.resources.requests.memory }}
+        {{- if .Values.check.storage.resources.limits }}
+        limits:
+          {{- if .Values.check.storage.resources.limits.cpu }}
+          cpu: {{ .Values.check.storage.resources.limits.cpu }}
+          {{- end }}
+          {{- if .Values.check.storage.resources.limits.memory }}
+          memory: {{ .Values.check.storage.resources.limits.memory }}
+          {{- end }}
+        {{- end }}
         {{- if $.Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -105,6 +105,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi    
   deployment:
     enabled: true
     runInterval: 10m

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -127,6 +127,12 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 25m
+        memory: 15Mi
+      limits:
+        cpu: 40m
   dnsInternal:
     enabled: true
     runInterval: 2m
@@ -143,6 +149,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   dnsExternal:
     enabled: false
     runInterval: 2m
@@ -159,6 +169,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   podRestarts:
     enabled: false
     runInterval: 5m
@@ -175,6 +189,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   podStatus:
     enabled: false
     runInterval: 5m
@@ -191,6 +209,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   storage:
   # external check from registry
   # https://github.com/ChrisHirsch/kuberhealthy-storage-check
@@ -213,6 +235,10 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   networkConnection:
     enabled: false
     runInterval: 30m
@@ -229,6 +255,9 @@ check:
     #  operator: "Equal"
     #  value: "value"
     #  effect: "NoSchedule"
+    resources:
+      requests:
+        memory: 5Mi
 
 checkReaper:
   enabled: true # Don't disable checkReaper, this flag exist to make e2e tests easier.
@@ -243,3 +272,7 @@ checkReaper:
     #  value: "value"
     #  effect: "NoSchedule"
   # startingDeadlineSeconds:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -258,6 +258,7 @@ check:
     resources:
       requests:
         memory: 5Mi
+        cpu: 10m
 
 checkReaper:
   enabled: true # Don't disable checkReaper, this flag exist to make e2e tests easier.


### PR DESCRIPTION
Allow to override resources from values.yaml instead of hard-coded values. Also this will help users specify the resource limits for cpu/memory. 
For now I have just updated it for daemonset check. If reviewers like the idea, I can update all the check definitions in this PR! This will help resolve #760 