### PR TITLE
Remove err.Error() from writeLog message

### DIFF
--- a/pkg/checks/external/checkclient/main.go
+++ b/pkg/checks/external/checkclient/main.go
@@ -95,7 +95,7 @@ func sendReport(s status.Report) error {
 		resp, err = http.Post(url, "application/json", bytes.NewBuffer(b))
 		return err
 	}, exponentialBackoff)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		writeLog("ERROR: got an error sending POST to kuberhealthy:", err)
 		return fmt.Errorf("bad POST request to kuberhealthy status reporting url: %w", err)
 	}

--- a/pkg/checks/external/checkclient/main.go
+++ b/pkg/checks/external/checkclient/main.go
@@ -96,7 +96,7 @@ func sendReport(s status.Report) error {
 		return err
 	}, exponentialBackoff)
 	if err != nil {
-		writeLog("ERROR: got an error sending POST to kuberhealthy:", err)
+		writeLog("ERROR: got an error sending POST to kuberhealthy:", err.Error())
 		return fmt.Errorf("bad POST request to kuberhealthy status reporting url: %w", err)
 	}
 

--- a/pkg/checks/external/checkclient/main.go
+++ b/pkg/checks/external/checkclient/main.go
@@ -96,7 +96,7 @@ func sendReport(s status.Report) error {
 		return err
 	}, exponentialBackoff)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		writeLog("ERROR: got an error sending POST to kuberhealthy:", err.Error())
+		writeLog("ERROR: got an error sending POST to kuberhealthy:", err)
 		return fmt.Errorf("bad POST request to kuberhealthy status reporting url: %w", err)
 	}
 


### PR DESCRIPTION
Addresses #761 

Possible fix for bug when sending report to kuberhealthy -- calling err.Error() in `writeLog` might not be valid, so removing and just using `err` similar to how we have it for all the other writeLog calls. 

I believe this error could have started when I made a change to add exponential backoff retry to the sendReport function