### PR TITLE
Fix 'no Auth Provider found for name azure'

### DIFF
--- a/pkg/kubeClient/client.go
+++ b/pkg/kubeClient/client.go
@@ -13,6 +13,7 @@ package kubeClient // import "github.com/Comcast/kuberhealthy/v2/pkg/kubeClient"
 
 import (
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
While testing an external check outside an k8s cluster using oidc authentication, I'm getting 
```
no Auth Provider found for name "azure"
```
This PR attempt to fix such issues when validating checks outside a k8s cluster that uses external sources for obtaining credentials.

More details can be found at https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/client-go/examples