### PR TITLE
build should not 'error' when skipping master builds

### DIFF
--- a/deploy/helm/helm-repo-update.sh
+++ b/deploy/helm/helm-repo-update.sh
@@ -6,7 +6,7 @@ if [[ ${GITHUB_REF##*/} =~ "v"[0-9].*\.[0-9].*\.[0-9].* ]]; then
 	sed -i -e "s/^version:.*/version: $GITHUB_RUN_NUMBER/" ./deploy/helm/kuberhealthy/Chart.yaml
 else
 	echo "invalid github reference supplied. exiting."
-	exit 1
+	exit 0
 fi
 
 # The github action we use has helm 3 (required) as 'helmv3' in its path, so we alias that in and use it if present


### PR DESCRIPTION
We have decided that we only want helm charts to be available after we tag a new release, but the current build script for the helm chart "errors" out with `exit 1` instead of `exit 0`.  This change allows the github action to complete successfully as expected.