### PR TITLE
feat: support multiple request types and configurable expected status code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - [Chris Hirsch](mailto:chris@base2technology.com)
 - [Adrian Aneci](mailto:aneci.adrian@gmail.com)
 - [Mike Tougeron](https://twitter.com/mtougeron)
+- [Yashvardhan Kukreja](https://twitter.com/yashkukreja98)

--- a/cmd/http-check/Makefile
+++ b/cmd/http-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/http-check:v1.3.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/http-check:v1.4.0 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/http-check:v1.3.2
+	docker push kuberhealthy/http-check:v1.4.0

--- a/cmd/http-check/README.md
+++ b/cmd/http-check/README.md
@@ -1,13 +1,14 @@
 ## HTTP Get Request Check
 
-The HTTP check sends a _GET_ request to a specified URL, looking for a 200 OK response. This check reports a success upon receiving a 200 OK and a failure on any other status code.
+The HTTP check can be configured to send a _GET_ / _POST_ / _PUT_ / _DELETE_ / _PATCH_ request to a specified URL, looking for a certain specific status code's response. This check reports a success upon receiving a response with the status code matching with the expected status code (like 200 or 204, etc.) and a failure on any other status code.
 
 You can specify the URL to check with the `CHECK_URL` environment variable in the `.yaml` file.
 
 The check will exit without sending a request if the specified URL is not prefixed with an HTTP or HTTPS protocol.
 
-#### Example HTTP Check Spec
+### Example HTTP Check Specs
 
+**GET check**
 ```yaml
 ---
 apiVersion: comcast.github.io/v1
@@ -21,11 +22,51 @@ spec:
   podSpec:
     containers:
       - name: http
-        image: kuberhealthy/http-check:v1.3.2
+        image: kuberhealthy/http-check:v1.4.0
         imagePullPolicy: IfNotPresent
         env:
           - name: CHECK_URL
             value: "http://google.com"
+        resources:
+          requests:
+            cpu: 15m
+            memory: 15Mi
+          limits:
+            cpu: 25m
+        restartPolicy: Always
+    terminationGracePeriodSeconds: 5
+```
+
+**POST check**
+```yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: http
+  namespace: kuberhealthy
+spec:
+  runInterval: 5m
+  timeout: 10m
+  podSpec:
+    containers:
+      - name: https
+        image: kuberhealthy/http-check:v1.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: CHECK_URL
+            value: "https://reqres.in/api/users"
+          - name: COUNT                #### default: "0"
+            value: "1"
+          - name: SECONDS              #### default: "0"
+            value: "1"
+          - name: PASSING_PERCENT      #### default: "100"
+            value: "100"
+          - name: REQUEST_TYPE         #### default: "GET"
+            value: "POST"
+          - name: REQUEST_BODY         #### default: "{}"
+            value: '{"name": "morpheus", "job": "leader"}'
+          - name: EXPECTED_STATUS_CODE #### default: "200"
+            value: "201"
         resources:
           requests:
             cpu: 15m

--- a/cmd/http-check/http-check.yaml
+++ b/cmd/http-check/http-check.yaml
@@ -8,18 +8,24 @@ spec:
   timeout: 10m
   podSpec:
     containers:
-      - name: http
-        image: kuberhealthy/http-check:v1.3.2
+      - name: https
+        image: kuberhealthy/http-check:v1.4.0
         imagePullPolicy: IfNotPresent
         env:
           - name: CHECK_URL
-            value: "http://google.com"
-          - name: COUNT
+            value: "https://reqres.in/api/users"
+          - name: COUNT            #### default: "0"
             value: "1"
-          - name: SECONDS
+          - name: SECONDS          #### default: "0"
             value: "1"
-          - name: PASSING_PERCENT
+          - name: PASSING_PERCENT  #### default: "100"
             value: "100"
+          - name: REQUEST_TYPE     #### default: "GET"
+            value: "POST"
+          - name: REQUEST_BODY     #### default: "{}"
+            value: '{"name": "morpheus", "job": "leader"}'
+          - name: EXPECTED_STATUS_CODE #### default: "200"
+            value: "201"
         resources:
           requests:
             cpu: 15m

--- a/cmd/http-check/main.go
+++ b/cmd/http-check/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -17,11 +19,20 @@ import (
 
 var (
 	// Environment Variables fetched from spec file
-	checkURL = os.Getenv("CHECK_URL")
-	count    = os.Getenv("COUNT")
-	seconds  = os.Getenv("SECONDS")
-	passing  = os.Getenv("PASSING_PERCENT")
+	checkURL           = os.Getenv("CHECK_URL")
+	count              = os.Getenv("COUNT")
+	seconds            = os.Getenv("SECONDS")
+	passing            = os.Getenv("PASSING_PERCENT")
+	requestType        = os.Getenv("REQUEST_TYPE")
+	requestBody        = os.Getenv("REQUEST_BODY")
+	expectedStatusCode = os.Getenv("EXPECTED_STATUS_CODE")
 )
+
+type APIRequest struct {
+	URL  string
+	Type string
+	Body io.Reader
+}
 
 func init() {
 	// set debug mode for nodeCheck pkg
@@ -41,6 +52,21 @@ func init() {
 	// Check that the SECONDS environment variable is valid.
 	if len(seconds) == 0 {
 		seconds = "0"
+	}
+
+	// Check that the REQUEST_TYPE environment variable is valid.
+	if len(requestType) == 0 {
+		requestType = "GET"
+	}
+
+	// Check that the REQUEST_BODY environment variable is valid.
+	if len(requestBody) == 0 {
+		requestBody = "{}"
+	}
+
+	// Check that the EXPECTED_STATUS_CODE environment variable is valid.
+	if len(expectedStatusCode) == 0 {
+		expectedStatusCode = "200"
 	}
 
 	// If the URL does not begin with HTTP, exit.
@@ -79,6 +105,17 @@ func main() {
 		ReportFailureAndExit(err)
 	}
 
+	expectedStatusCodeInt, err := strconv.Atoi(expectedStatusCode)
+	if err != nil {
+		err = fmt.Errorf("Error converting EXPECTED_STATUS_CODE to int: " + err.Error())
+		ReportFailureAndExit(err)
+	}
+
+	// if the expected status code is empty, then default to 200
+	if expectedStatusCodeInt == 0 {
+		expectedStatusCodeInt = 200
+	}
+
 	// if the passing count is empty, then default to 100%
 	if passingInt == 0 {
 		passingInt = 100
@@ -106,7 +143,11 @@ func main() {
 	// This for loop makes a http GET request to a known internet address, address can be changed in deployment spec yaml
 	// and returns a http status every second.
 	for checksRan < countInt {
-		r, err := http.Get(checkURL)
+		r, err := callAPI(APIRequest{
+			URL:  checkURL,
+			Type: requestType,
+			Body: bytes.NewBuffer([]byte(requestBody)),
+		})
 		checksRan++
 
 		if err != nil {
@@ -115,7 +156,7 @@ func main() {
 			continue
 		}
 
-		if r.StatusCode != http.StatusOK {
+		if r.StatusCode != expectedStatusCodeInt {
 			log.Errorln("Got a", r.StatusCode, "with a", http.MethodGet, "to", checkURL)
 			checksFailed++
 			continue
@@ -136,7 +177,7 @@ func main() {
 
 	// Check to see if the number of requests passed at passingPercent and reports to Kuberhealthy accordingly
 	if checksPassed < passInt {
-		reportErr := fmt.Errorf("unable to retrieve a valid response from " + checkURL + " check failed " + strconv.Itoa(checksFailed) + " out of " + strconv.Itoa(checksRan) + " attempts")
+		reportErr := fmt.Errorf("unable to retrieve a valid response (expected status: %d) from %s %s checks failed %d out of %d attempts", expectedStatusCodeInt, requestType, checkURL, checksFailed, checksRan)
 		ReportFailureAndExit(reportErr)
 	}
 
@@ -156,4 +197,32 @@ func ReportFailureAndExit(err error) {
 		log.Fatalln("error when reporting to kuberhealthy:", err.Error())
 	}
 	os.Exit(0)
+}
+
+// callAPI performs an API call on the basis of the request type, body and URL provided to it.
+// It returns the response corresponding to the request.
+func callAPI(request APIRequest) (*http.Response, error) {
+	var response *http.Response
+	switch request.Type {
+	case "GET":
+		resp, err := http.Get(request.URL)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while calling %s: %w", request.URL, err)
+		}
+		response = resp
+	case "POST", "PUT", "DELETE", "PATCH":
+		req, err := http.NewRequest(string(request.Type), request.URL, request.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while calling %s: %w", request.URL, err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while calling %s: %w", request.URL, err)
+		}
+		response = resp
+	default:
+		return nil, fmt.Errorf("error occurred while calling %s: wrong request type found", request.URL)
+	}
+
+	return response, nil
 }


### PR DESCRIPTION
closes #779 

Updated the docs and version of the http-check image as well.
The following are the new configurable environment variables for the http-check

```yaml
      env:
          - name: CHECK_URL
            value: "https://reqres.in/api/users"
          - name: COUNT                #### default: "0"
            value: "1"
          - name: SECONDS              #### default: "0"
            value: "1"
          - name: PASSING_PERCENT      #### default: "100"
            value: "100"
          - name: REQUEST_TYPE         #### default: "GET"
            value: "POST"
          - name: REQUEST_BODY         #### default: "{}"
            value: '{"name": "morpheus", "job": "leader"}'
          - name: EXPECTED_STATUS_CODE #### default: "200"
            value: "201"
```

**Sample output of a failing check**
```json
"kuberhealthy/http": {
      "OK": false,
      "Errors": [
        "unable to retrieve a valid response (expected status: 201) from POST https://reqres.in/api/users checks failed 1 out of 1 attempts"
      ],
      "RunDuration": "39.511730386s",
      "Namespace": "kuberhealthy",
      "LastRun": "2021-01-18T21:48:33.614078779Z",
      "AuthoritativePod": "kuberhealthy-7b5b54ddb7-sggnz",
      "uuid": "e426be13-4a17-4db1-896e-26521f8bb02c"
    }
```