### PR TITLE
add printer columns

### DIFF
--- a/deploy/helm/kuberhealthy/crds/khstate.yaml
+++ b/deploy/helm/kuberhealthy/crds/khstate.yaml
@@ -13,3 +13,16 @@ spec:
     kind: KuberhealthyState
     shortNames:
       - khs
+  additionalPrinterColumns:
+    - description: OK status
+      JSONPath: .spec.OK
+      name: OK
+      type: string
+    - description: Last Run
+      JSONPath: .spec.LastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date

--- a/deploy/kuberhealthy-prometheus-operator.yaml
+++ b/deploy/kuberhealthy-prometheus-operator.yaml
@@ -43,6 +43,19 @@ spec:
     kind: KuberhealthyState
     shortNames:
       - khs
+  additionalPrinterColumns:
+    - description: OK status
+      JSONPath: .spec.OK
+      name: OK
+      type: string
+    - description: Last Run
+      JSONPath: .spec.LastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 ---
 # Source: kuberhealthy/templates/poddisruptionbudget.yaml
 apiVersion: policy/v1beta1

--- a/deploy/kuberhealthy-prometheus.yaml
+++ b/deploy/kuberhealthy-prometheus.yaml
@@ -43,6 +43,19 @@ spec:
     kind: KuberhealthyState
     shortNames:
       - khs
+  additionalPrinterColumns:
+    - description: OK status
+      JSONPath: .spec.OK
+      name: OK
+      type: string
+    - description: Last Run
+      JSONPath: .spec.LastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 ---
 # Source: kuberhealthy/templates/poddisruptionbudget.yaml
 apiVersion: policy/v1beta1

--- a/deploy/kuberhealthy.yaml
+++ b/deploy/kuberhealthy.yaml
@@ -43,6 +43,19 @@ spec:
     kind: KuberhealthyState
     shortNames:
       - khs
+  additionalPrinterColumns:
+    - description: OK status
+      JSONPath: .spec.OK
+      name: OK
+      type: string
+    - description: Last Run
+      JSONPath: .spec.LastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 ---
 # Source: kuberhealthy/templates/poddisruptionbudget.yaml
 apiVersion: policy/v1beta1


### PR DESCRIPTION
hi
Sometimes it is useful an overview of statuses:
```
$ kubectl get khs 
NAME                  OK     AGE LASTRUN   AGE
daemonset             true   4m37s         50m
deployment            true   8m19s         50m
dns-status-internal   true   111s          50m

```

note: this is changing a little bit in apiextensions.k8s.io/v1.
