### PR TITLE
Update helm-repo-update.sh

### DIFF
--- a/deploy/helm/helm-repo-update.sh
+++ b/deploy/helm/helm-repo-update.sh
@@ -1,13 +1,21 @@
 
 # Modify Chart.yaml based on whether workflow was triggered by a new tag or a file update in ./deploy/helm
 echo "GITHUB_REF: ${GITHUB_REF##*/}"
+# if [[ ${GITHUB_REF##*/} =~ "v"[0-9].*\.[0-9].*\.[0-9].* ]]; then
+# 	sed -i -e "s/^appVersion:.*/appVersion: ${GITHUB_REF##*/}/" ./deploy/helm/kuberhealthy/Chart.yaml
+# 	sed -i -e "s/^version:.*/version: $GITHUB_RUN_NUMBER/" ./deploy/helm/kuberhealthy/Chart.yaml
+# else
+# 	echo "invalid github reference supplied. exiting."
+# 	exit 0
+# fi
+
+# When a tag is created, we up the appVersion in the chart, but each time we merge to master 
+# we will up the chart version to match the github action number
 if [[ ${GITHUB_REF##*/} =~ "v"[0-9].*\.[0-9].*\.[0-9].* ]]; then
 	sed -i -e "s/^appVersion:.*/appVersion: ${GITHUB_REF##*/}/" ./deploy/helm/kuberhealthy/Chart.yaml
-	sed -i -e "s/^version:.*/version: $GITHUB_RUN_NUMBER/" ./deploy/helm/kuberhealthy/Chart.yaml
-else
-	echo "invalid github reference supplied. exiting."
-	exit 0
 fi
+sed -i -e "s/^version:.*/version: $GITHUB_RUN_NUMBER/" ./deploy/helm/kuberhealthy/Chart.yaml
+
 
 # The github action we use has helm 3 (required) as 'helmv3' in its path, so we alias that in and use it if present
 HELM="helm"


### PR DESCRIPTION
This changes our helm chart so that when a tag is made for the project, we up the appVersion in the chart.  Also, whenever any change to the chart is merged to master, the automation will build a new unique helm chart version.  This means that the helm chart is no longer published at the same time as kuberhealthy.