### PR TITLE
fixed: helm error while applying check-reaper

### DIFF
--- a/deploy/helm/kuberhealthy/templates/check-reaper.yaml
+++ b/deploy/helm/kuberhealthy/templates/check-reaper.yaml
@@ -38,7 +38,7 @@ spec:
                 - name: SINGLE_NAMESPACE
                   value: ""
                 - name: MAX_PODS_THRESHOLD
-                  value: {{ .Values.checkReaper.maxPodsThreshold | toString }}
+                  value: {{ quote .Values.checkReaper.maxPodsThreshold }}
                 - name: JOB_DELETE_TIME_DURATION
                   value: {{ .Values.checkReaper.jobDeleteTimeDuration }}
               securityContext:


### PR DESCRIPTION
closes #801 

**Before this PR**
```
► helm install kuberhealthy . -f values.yaml
Error: CronJob in version "v1beta1" cannot be handled as a CronJob: v1beta1.CronJob.Spec: v1beta1.CronJobSpec.JobTemplate: v1beta1.JobTemplateSpec.Spec: v1.JobSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.v1.EnvVar.Value: ReadString: expects " or n, but found 4, error found in #10 byte of ...|,"value":4},{"name":|..., bigger context ...|"value":""},{"name":"MAX_PODS_THRESHOLD","value":4},{"name":"JOB_DELETE_TIME_DURATION","value":"15m"|...
```

**After this PR**
```
► helm install kuberhealthy . -f values.yaml
NAME: kuberhealthy
LAST DEPLOYED: Thu Jan 28 01:17:37 2021
NAMESPACE: kuberhealthy
STATUS: deployed
REVISION: 1
TEST SUITE: None
```