### PR TITLE
removing random string from helm template for check reaper

### DIFF
--- a/deploy/helm/kuberhealthy/templates/check-reaper.yaml
+++ b/deploy/helm/kuberhealthy/templates/check-reaper.yaml
@@ -38,7 +38,7 @@ spec:
                 - name: SINGLE_NAMESPACE
                   value: ""
                 - name: MAX_PODS_THRESHOLD
-                  value: {{ quote .Values.checkReaper.maxPodsThreshold }}
+                  value: {{ .Values.checkReaper.maxPodsThreshold }}
                 - name: JOB_DELETE_TIME_DURATION
                   value: {{ .Values.checkReaper.jobDeleteTimeDuration }}
               securityContext:


### PR DESCRIPTION
looks like in the check-reaper template for helm the string `quote` was put into the MAX_PODS_THRESHOLD env variable value. I verified locally the same issue reported in #807. I am unsure why this is in the master branch. Please confirm 