### PR TITLE
updating check veresion to redeploy with kube-deploy

### DIFF
--- a/cmd/http-check/Makefile
+++ b/cmd/http-check/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t kuberhealthy/http-check:v1.4.2 -f Dockerfile ../../
+	docker build -t kuberhealthy/http-check:v1.4.3 -f Dockerfile ../../
 
 push:
-	docker push kuberhealthy/http-check:v1.4.2
+	docker push kuberhealthy/http-check:v1.4.3

--- a/cmd/http-check/README.md
+++ b/cmd/http-check/README.md
@@ -18,16 +18,28 @@ metadata:
   name: http
   namespace: kuberhealthy
 spec:
-  runInterval: 2m
-  timeout: 6m
+  runInterval: 5m
+  timeout: 10m
   podSpec:
     containers:
-      - name: http
-        image: kuberhealthy/http-check:v1.4.2
+      - name: https
+        image: kuberhealthy/http-check:v1.4.3
         imagePullPolicy: IfNotPresent
         env:
           - name: CHECK_URL
-            value: "http://google.com"
+            value: "https://reqres.in/api/users"
+          - name: COUNT #### default: "0"
+            value: "5"
+          - name: SECONDS #### default: "0"
+            value: "1"
+          - name: PASSING_PERCENT #### default: "100"
+            value: "80"
+          - name: REQUEST_TYPE #### default: "GET"
+            value: "POST"
+          - name: REQUEST_BODY #### default: "{}"
+            value: '{"name": "morpheus", "job": "leader"}'
+          - name: EXPECTED_STATUS_CODE #### default: "200"
+            value: "201"
         resources:
           requests:
             cpu: 15m
@@ -52,7 +64,7 @@ spec:
   podSpec:
     containers:
       - name: https
-        image: kuberhealthy/http-check:v1.4.1
+        image: kuberhealthy/http-check:v1.4.3
         imagePullPolicy: IfNotPresent
         env:
           - name: CHECK_URL

--- a/cmd/http-check/http-check.yaml
+++ b/cmd/http-check/http-check.yaml
@@ -9,7 +9,7 @@ spec:
   podSpec:
     containers:
       - name: https
-        image: kuberhealthy/http-check:v1.4.2
+        image: kuberhealthy/http-check:v1.4.3
         imagePullPolicy: IfNotPresent
         env:
           - name: CHECK_URL


### PR DESCRIPTION
I want to update the version of http-check. Looks like the version running in prod was the same as the revisions made from the last feature request. I needed to apply the new spec file to prod but the image pull policy was IfNotPresent. I am upping the version to make sure we are all on the same page. I do have this image built and running in prod currently.