### PR TITLE
add err to errMessages and update required role

### DIFF
--- a/cmd/pod-restarts-check/main.go
+++ b/cmd/pod-restarts-check/main.go
@@ -143,6 +143,10 @@ func (prc *Checker) Run() error {
 	case err := <-doneChan:
 		if len(prc.BadPods) != 0 || err != nil {
 			var errorMessages []string
+			if err != nil {
+				log.Error(err)
+				errorMessages = append(errorMessages, err.Error())
+			}
 			for _, msg := range prc.BadPods {
 				errorMessages = append(errorMessages, msg)
 			}

--- a/cmd/pod-restarts-check/pod-restarts-check.yaml
+++ b/cmd/pod-restarts-check/pod-restarts-check.yaml
@@ -55,6 +55,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+
 ---
 # Source: kuberhealthy/templates/khcheck-pod-restarts.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -88,6 +88,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
- fixed updating `errorMessages` with  `err` 
- fixed pod-restarts-check rbac role to be able to list events

Fixes #828 

Signed-off-by: Isa Aguilar <isa@aguilarstory.com>