### PR TITLE
fix: Set proper pod port where prometheus metrics are exposed

### DIFF
--- a/deploy/helm/kuberhealthy/templates/service.yaml
+++ b/deploy/helm/kuberhealthy/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
   {{- if and .Values.prometheus.enabled (not .Values.prometheus.serviceMonitor.enabled) }}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "80"
+    prometheus.io/port: "8080"
     prometheus.io/path: "/metrics"
   {{- end }}
   {{- range $key, $value := .Values.service.annotations }}

--- a/deploy/kuberhealthy-prometheus.yaml
+++ b/deploy/kuberhealthy-prometheus.yaml
@@ -321,7 +321,7 @@ metadata:
   namespace: kuberhealthy
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "80"
+    prometheus.io/port: "8080"
     prometheus.io/path: "/metrics"
 spec:
   type: ClusterIP

--- a/docs/K8s-KPIs-with-Kuberhealthy.md
+++ b/docs/K8s-KPIs-with-Kuberhealthy.md
@@ -105,7 +105,7 @@ To learn more about writing your own checks, along with simple examples, check t
 When enabling Prometheus (not the operator), the Kuberhealthy service gets the following annotations added:
 ```.env
 prometheus.io/path: /metrics
-prometheus.io/port: "80"
+prometheus.io/port: "8080"
 prometheus.io/scrape: "true"
 ```
 


### PR DESCRIPTION
Currently, prometheus-server tries to scrape metrics from pod's port 80 which isn't exposed.
According to default prometheus [kubernetes_sd_config](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml#L1592) service annotation `prometheus.io/port` should point to pod's port instead of service port. 
