### PR TITLE
Fix for khcheck-storage template

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -18,8 +18,8 @@ spec:
     {{- end }}
     containers:
     - name: main
-      {{- if .Values.imageRegistry }}
-      image: {{ .Values.imageRegistry }}/{{ .Values.check.storage.image.repository }}:{{ .Values.check.storage.image.tag }}
+      {{- if $.Values.imageRegistry }}
+      image: {{ $.Values.imageRegistry }}/{{ .Values.check.storage.image.repository }}:{{ .Values.check.storage.image.tag }}
       {{- else if .Values.check.storage.image.registry }}
       image: {{ .Values.check.storage.image.registry }}/{{ .Values.check.storage.image.repository }}:{{ .Values.check.storage.image.tag }}
       {{- end }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -19,9 +19,9 @@ spec:
     containers:
     - name: main
       {{- if $.Values.imageRegistry }}
-      image: {{ $.Values.imageRegistry }}/{{ .Values.check.storage.image.repository }}:{{ .Values.check.storage.image.tag }}
-      {{- else if .Values.check.storage.image.registry }}
-      image: {{ .Values.check.storage.image.registry }}/{{ .Values.check.storage.image.repository }}:{{ .Values.check.storage.image.tag }}
+      image: {{ $.Values.imageRegistry }}/{{ $.Values.check.storage.image.repository }}:{{ $.Values.check.storage.image.tag }}
+      {{- else if $.Values.check.storage.image.registry }}
+      image: {{ $.Values.check.storage.image.registry }}/{{ $.Values.check.storage.image.repository }}:{{ $.Values.check.storage.image.tag }}
       {{- end }}
       imagePullPolicy: IfNotPresent
       env:
@@ -41,15 +41,15 @@ spec:
 {{- end }}
       resources:
         requests:
-          cpu: {{ .Values.check.storage.resources.requests.cpu }}
-          memory: {{ .Values.check.storage.resources.requests.memory }}
-        {{- if .Values.check.storage.resources.limits }}
+          cpu: {{ $.Values.check.storage.resources.requests.cpu }}
+          memory: {{ $.Values.check.storage.resources.requests.memory }}
+        {{- if $.Values.check.storage.resources.limits }}
         limits:
-          {{- if .Values.check.storage.resources.limits.cpu }}
-          cpu: {{ .Values.check.storage.resources.limits.cpu }}
+          {{- if $.Values.check.storage.resources.limits.cpu }}
+          cpu: {{ $.Values.check.storage.resources.limits.cpu }}
           {{- end }}
-          {{- if .Values.check.storage.resources.limits.memory }}
-          memory: {{ .Values.check.storage.resources.limits.memory }}
+          {{- if $.Values.check.storage.resources.limits.memory }}
+          memory: {{ $.Values.check.storage.resources.limits.memory }}
           {{- end }}
         {{- end }}
         {{- if $.Values.securityContext.enabled }}


### PR DESCRIPTION
This addresses https://github.com/Comcast/kuberhealthy/issues/895

Many of the variables referenced inside khcheck-storage failed with the following error:

> `Error: template: kuberhealthy/templates/khcheck-storage.yaml:24:23: executing "kuberhealthy/templates/khcheck-storage.yaml" at <.Values.check.storage.image.registry>: can't evaluate field Values in type interface {}`


> `Error: template: kuberhealthy/templates/khcheck-storage.yaml:44:25: executing "kuberhealthy/templates/khcheck-storage.yaml" at <.Values.check.storage.resources.requests.cpu>: can't evaluate field Values in type interface {}`

this due to helm not being able to render the variables correctly inside the given {{ range }}. The $ notation fixes this (ref: https://helm.sh/docs/chart_template_guide/variables/)

I was able to test this in my local env with the default values.yaml, except with the addition of:

 ```  storage:
  # external check from registry
  # https://github.com/ChrisHirsch/kuberhealthy-storage-check
    **enabled: true**
    # empty string indicate default storage class
    # kubectl get storageclass
    # or put storage class names into list
    **storageClass: ["managed-premium"]**
    runInterval: 5m
    timeout: 10m
    image:
      registry: chrishirsch
      repository: kuberhealthy-storage-check
      tag: v0.0.1
    extraEnvs:
      CHECK_STORAGE_IMAGE: bitnami/nginx:1.19
      CHECK_STORAGE_INIT_IMAGE: bitnami/nginx:1.19
    nodeSelector: {}
    tolerations: []
    #- key: "key"
    #  operator: "Equal"
    #  value: "value"
    #  effect: "NoSchedule"
    resources:
      requests:
        cpu: 10m
        memory: 50Mi```
