### PR TITLE
Add support for affinity to allow spreading of kuberhealthy pods acro…

### DIFF
--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                - {{ template "kuberhealthy.name" . }}
+                  - {{ template "kuberhealthy.name" . }}
               topologyKey: "kubernetes.io/hostname"
 {{- end }}
 {{- end }}

--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -38,6 +38,35 @@ spec:
       {{- if .Values.deployment.priorityClassName }}
       priorityClassName: {{ .Values.deployment.priorityClassName }}
       {{- end}}
+{{- if or .Values.deployment.affinity  .Values.deployment.podAntiAffinity }}
+      affinity:
+{{- if .Values.deployment.affinity }}
+{{ toYaml .Values.deployment.affinity | indent 8 }}
+{{- end }}
+{{- if eq .Values.deployment.podAntiAffinity "hard"}}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "kuberhealthy.name" . }}
+            topologyKey: "kubernetes.io/hostname"
+{{else if eq .Values.deployment.podAntiAffinity "soft"}}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                - {{ template "kuberhealthy.name" . }}
+              topologyKey: "kubernetes.io/hostname"
+{{- end }}
+{{- end }}
       containers:
       {{- if .Values.imageRegistry }}
       - image: {{ .Values.imageRegistry }}/{{ .Values.image.repository }}:{{ .Chart.AppVersion }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -70,6 +70,11 @@ deployment:
   - /app/kuberhealthy
   # args:
   # priorityClassName:
+  affinity: {}
+  ## Acceptable values for podAntiAffinity:
+  ## soft: specifies preferences that the scheduler will try to enforce but will not guarantee (Default)
+  ## hard: specifies rules that must be met for a pod to be scheduled onto a node
+  podAntiAffinity: "soft"
 
 # When enabled equals to true, runAsUser and fsGroup will be
 # included to all khchecks as specified below.


### PR DESCRIPTION
Currently there isn't support for specifying the affinity/podAntiAffinity for Kuberhealthy pods. We noticed it when our Kuberhealthy pods in production env were running on the same node :)

kuberhealthy-5ccb966f45-5nngq 1/1 Running 0 2d7h 10.39.0.209 aks-xxxxx-15091357-vmss000002 <none> <none>
kuberhealthy-5ccb966f45-pjpg8 1/1 Running 0 2d7h 10.39.0.190 aks-xxxxx-15091357-vmss000002 <none> <none>

This PR will help you specify/apply those settings optionally to allow spreading of Kuberhealthy pods across nodes.