### PR TITLE
don't use 'latest' for master builds

### DIFF
--- a/.github/workflows/build-latest-docker.yml
+++ b/.github/workflows/build-latest-docker.yml
@@ -1,4 +1,4 @@
-name: Build and Push kuberhealthy Latest
+name: Build and Push kuberhealthy Unstable
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ on:
     paths:
       - "cmd/kuberhealthy/**"
 env:
-    IMAGE_NAME: kuberhealthy
+    IMAGE_NAME: kuberhealthy/kuberhealthy:unstable
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,5 +20,4 @@ jobs:
       run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u integrii --password-stdin
     - name: Push new latest image
       run: |
-          docker tag $IMAGE_NAME kuberhealthy/$IMAGE_NAME
-          docker push kuberhealthy/$IMAGE_NAME
+          docker push $IMAGE_NAME


### PR DESCRIPTION
- currently when a merge is done to master, a build is kicked off automatically with github actions
- this build automatically tags the image as 'latest' because no image tag is supplied
- this is then uploaded to docker hub automatically
- so, anyone who uses our image without specifying a tag, gets an unstable version


This PR makes it so new builds are tagged as `kuberhealthy/kuberhealthy:unstable` as they build off master.  Additional documentation has been added to instruct release managers to tag the build as an actual release version and push it to docker hub.